### PR TITLE
[박문아]sprint1

### DIFF
--- a/src/main/java/com/sprint/mission/discodeit/entity/BaseEntity.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BaseEntity.java
@@ -1,0 +1,42 @@
+package com.sprint.mission.discodeit.entity;
+
+import java.util.UUID;
+
+public abstract class BaseEntity {
+    private UUID id;
+    private long createdAt;
+    private long updatedAt;
+
+    //기본생성자
+    public BaseEntity() {
+        this.id=UUID.randomUUID(); //고유식별자 생성
+        this.createdAt=System.currentTimeMillis();//생성시간
+        this.updatedAt=this.createdAt;//초기수정시간은 생성시간과 같게
+    }
+
+
+    public UUID getId() {
+        return id;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+    public long getUpdatedAt() {
+        return updatedAt;
+    }
+    public void update(){ //파라미터 추가 필요
+        this.updatedAt=System.currentTimeMillis();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("BaseEntity{");
+        sb.append("id=").append(id);
+        sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
@@ -1,0 +1,39 @@
+package com.sprint.mission.discodeit.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Channel extends BaseEntity {
+    private String channelName; //채널명
+    private String description; //채널 이름
+
+    public Channel(String channelName, String description){
+        super();
+        this.channelName=channelName;
+        this.description=description;
+    }
+
+    public String getChannelName() {
+        return channelName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+
+    public void update(String channelName, String description){
+        super.update();
+        this.description=description;
+        this.channelName=channelName;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("Channel{");
+        sb.append("channelName='").append(channelName).append('\'');
+        sb.append(", description='").append(description);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/Message.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Message.java
@@ -1,0 +1,42 @@
+package com.sprint.mission.discodeit.entity;
+
+import java.util.UUID;
+
+public class Message extends BaseEntity {
+    private UUID userId;
+    private UUID channelId;
+    private String content;
+
+    public Message(UUID userId,UUID channelId,String content){
+        super();
+        this.userId=userId;
+        this.channelId=channelId;
+        this.content=content;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public UUID getChannelId() {
+        return channelId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+    public void update(String content){
+        super.update();
+        this.content=content;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("Message{");
+        sb.append("userId=").append(userId);
+        sb.append(", channelId=").append(channelId);
+        sb.append(", content='").append(content).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/User.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/User.java
@@ -1,0 +1,41 @@
+package com.sprint.mission.discodeit.entity;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class User extends BaseEntity {
+    private String username;
+    private String password;
+
+    public User(String username, String password){
+        super();
+        this.username=username;
+        this.password=password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+
+    public void update(String username,String password){
+        super.update();
+        this.username=username;
+        this.password=password;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("User{");
+        sb.append(super.getId());
+        sb.append("username='").append(username).append('\'');
+        sb.append(", password='").append(password);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/run/JavaApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/run/JavaApplication.java
@@ -1,0 +1,322 @@
+package com.sprint.mission.discodeit.run;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.jcf.JCFChannelService;
+import com.sprint.mission.discodeit.service.jcf.JCFMessageService;
+import com.sprint.mission.discodeit.service.jcf.JCFUserService;
+
+import java.util.List;
+import java.util.Scanner;
+import java.util.UUID;
+
+public class JavaApplication {
+    private static final JCFChannelService cs = new JCFChannelService();
+    private static final JCFUserService us = new JCFUserService();
+    private static final JCFMessageService ms = new JCFMessageService();
+    private static final Scanner sc = new Scanner(System.in);
+
+    public static void main(String[] args) {
+        JavaApplication app = new JavaApplication();
+        app.mainMenu();
+    }
+
+    public void mainMenu() {
+        System.out.println("==========디스코드==========");
+        while (true) {
+
+            System.out.println("***** 메인 메뉴 *****");
+            System.out.println("1. 등록");
+            System.out.println("2. 조회");
+            System.out.println("3. 수정");
+            System.out.println("4. 삭제");
+            System.out.println("9. 종료");
+            System.out.print("메뉴 번호 입력 : ");
+            String num =sc.nextLine();
+            switch (num) {
+                case "1":
+                    registerMenu();
+                    break;
+                case "2":
+                    readMenu();
+                    break;
+                case "3":
+                    modifyMenu();
+                    break;
+                case "4":
+                    deleteMenu();
+                    break;
+                case "9":
+                    System.out.println("프로그램 종료");
+                    return;
+                default:
+                    System.out.println("잘못입력하였습니다. 다시입력해주세요");
+            }
+
+        }
+
+    }
+
+    public void registerMenu() {
+        while (true) {
+            System.out.println("=== 등록 ===");
+            System.out.println("1. 등록 - 채널");
+            System.out.println("2. 등록 - 사용자");
+            System.out.println("3. 등록 - 메시지");
+            System.out.println("9. 전 페이지로");
+            System.out.print("메뉴 번호 입력 >> ");
+            String num =sc.nextLine();
+            switch (num){
+                case "1":
+                    inputChannel();
+                    continue;
+                case "2":
+                    inputUser();
+                    continue;
+                case "3":
+                    inputMessage();
+                    continue;
+                case "9":
+                    return;
+                default:
+                    System.out.println("잘못입력하였습니다. 다시 입력해주세요.");
+            }
+
+        }
+    }
+
+
+    public void readMenu() {
+        while (true) {
+            System.out.println("=== 조회 ===");
+            System.out.println("1. 단건 - 채널");
+            System.out.println("2. 단건 - 사용자");
+            System.out.println("3. 단건 - 메시지");
+            System.out.println("-------------------");
+            System.out.println("4. 다건 - 전체 채널");
+            System.out.println("5. 다건 - 전체 사용자");
+            System.out.println("6. 다건 - 전체 메시지");
+            System.out.println("9. 전 페이지로");
+            System.out.print("메뉴 번호 입력 >> ");
+            String num =sc.nextLine();
+            switch (num){
+                case "1":
+                    oneChannel();
+                    continue;
+                case "2":
+                    oneUser();
+                    continue;
+                case "3":
+                    oneMessage();
+                    continue;
+                case "4":
+                    allChannel();
+                    continue;
+                case "5":
+                    allUser();
+                    continue;
+                case "6":
+                    allMessage();
+                    continue;
+
+                case "9":
+                    return;
+                default:
+                    System.out.println("잘못입력하였습니다. 다시 입력해주세요.");
+            }
+
+        }
+    }
+
+    public void modifyMenu() {
+        while (true) {
+            System.out.println("=== 수정 ===");
+            System.out.println("1. 수정 - 채널");
+            System.out.println("2. 수정 - 사용자");
+            System.out.println("3. 수정 - 메시지");
+            System.out.println("9. 전 페이지로");
+            System.out.print("메뉴 번호 입력 >> ");
+            int num =Integer.parseInt(sc.nextLine());
+            switch (num){
+                case 1:
+                    updateChannel();
+                    continue;
+                case 2:
+                    updateUser();
+                    continue;
+                case 3:
+                    updateMessage();
+                    continue;
+                case 9:
+                    return;
+                default:
+                    System.out.println("잘못입력하였습니다. 다시 입력해주세요.");
+            }
+
+        }
+    }
+
+    public void deleteMenu() {
+        while (true) {
+            System.out.println("=== 삭제 ===");
+            System.out.println("1. 삭제 - 채널");
+            System.out.println("2. 삭제 - 사용자");
+            System.out.println("3. 삭제 - 메시지");
+            System.out.println("9. 전 페이지로");
+            System.out.print("메뉴 번호 입력 >> ");
+            int num =Integer.parseInt(sc.nextLine());
+            switch (num){
+                case 1:
+                    deleteChannel();
+                    continue;
+                case 2:
+                    deleteUser();
+                    continue;
+                case 3:
+                    deleteMessage();
+                    continue;
+                case 9:
+                    return;
+                default:
+                    System.out.println("잘못입력하였습니다. 다시 입력해주세요.");
+            }
+
+        }
+
+    }
+
+    public void inputChannel(){
+        System.out.println("=== 등록 - 채널===");
+        System.out.print("채널 이름 :");
+        String name=sc.nextLine();
+        System.out.print("채널 내용 :");
+        String description=sc.nextLine();
+        cs.createChannel(name,description);
+        System.out.println("성공적으로 생성 완료하였습니다.");
+    }
+    public void inputUser() {
+        System.out.println("=== 등록 - 사용자===");
+        System.out.print("별명 :");
+        String name = sc.nextLine();
+        System.out.print("비밀번호 :");
+        String password = sc.nextLine();
+        us.createUser(name,password);
+    }
+
+    public void inputMessage(){
+        System.out.println("=== 등록 - 메시지===");
+        System.out.print("사용자 이름 :");
+        UUID name=UUID.fromString(sc.nextLine());
+        System.out.print("채널 이름 :");
+        UUID channel=UUID.fromString(sc.nextLine());
+        System.out.print("메시지 내용 :");
+        String content=sc.nextLine();
+        if (us.readByIdUser(name) !=null && cs.readByIdChannel(channel)!=null){
+            ms.createMessage(name, channel, content);
+            System.out.println("메시지 등록에 성공하였습니다.");
+        }else{
+            System.out.println("사용자명이나 채널명이 존재하지 않습니다.");
+        }
+
+    }
+
+    public void oneChannel(){
+        System.out.println("=== 단건 - 채널 ===");
+        System.out.print("채널 UUID :");
+        UUID name=UUID.fromString(sc.nextLine());
+        Channel channel=cs.readByIdChannel(name);
+        if(channel!=null){
+            System.out.println(channel);
+        }else{
+            System.out.println("채널 조회에 실패하였습니다.");
+        }
+    }
+    public void oneUser(){
+        System.out.println("=== 단건 - 사용자 ===");
+        System.out.print("사용자 UUID :");
+        UUID name=UUID.fromString(sc.nextLine());
+        User user=us.readByIdUser(name);
+        if(user!=null){
+            System.out.println(user);
+        }else{
+            System.out.println("사용자 조회에 실패하였습니다.");
+        }
+    }
+    public void oneMessage(){
+        System.out.println("=== 단건 - 메시지 ===");
+        System.out.print("메시지 UUID :");
+        UUID name=UUID.fromString(sc.nextLine());
+        Message message=ms.readByIdMessage(name);
+        if(message!=null){
+            System.out.println(message);
+        }else{
+            System.out.println("메시지 조회에 실패하였습니다.");
+        }
+    }
+
+    public void allChannel(){
+        System.out.println("=== 다건 - 전체 채널 ===");
+        cs.readAllChannel();
+    }
+    public void allUser(){
+        System.out.println("=== 다건 - 전체 사용자 ===");
+        us.readAllUser();
+    }
+    public void allMessage(){
+        System.out.println("=== 다건 - 전체 메시지 ===");
+        ms.readAllMessage();
+    }
+
+
+    public void updateChannel(){
+        System.out.println("=== 수정 - 채널 ===");
+        System.out.print("채널 UUID : ");
+        UUID channelUUID = UUID.fromString(sc.nextLine());
+        System.out.print("채널 이름 :");
+        String channelName = sc.nextLine();
+        System.out.print("채널 설명 : ");
+        String description = sc.nextLine();
+        cs.updateChannel(channelUUID,channelName,description);
+    }
+
+    public void updateUser(){
+        System.out.println("=== 수정 - 사용자 ===");
+        System.out.print("사용자 UUID : ");
+        UUID userUUID = UUID.fromString(sc.nextLine());
+        System.out.print("사용자 이름 :");
+        String userName = sc.nextLine();
+        System.out.print("비밀번호 : ");
+        String password = sc.nextLine();
+        us.updateUser(userUUID,userName, password);
+
+    }
+    public void updateMessage(){
+        System.out.println("=== 수정 - 메시지 ===");
+        System.out.print("메시지 UUID : ");
+        UUID messageUUID = UUID.fromString(sc.nextLine());
+        System.out.print("메시지 내용 :");
+        String content = sc.nextLine();
+        ms.updateMessage(messageUUID, content);
+    }
+
+    public void deleteChannel(){
+        System.out.println("=== 삭제 - 채널 ===");
+        System.out.print("채널 UUID : ");
+        UUID channelUUID = UUID.fromString(sc.nextLine());
+        cs.deleteByIdChannel(channelUUID);
+    }
+    public void deleteMessage(){
+        System.out.println("=== 삭제 - 메시지 ===");
+        System.out.print("메시지 UUID : ");
+        UUID messageUUID = UUID.fromString(sc.nextLine());
+        ms.deleteByIdMessage(messageUUID);
+    }
+    public void deleteUser(){
+        System.out.println("=== 삭제 - 사용자 ===");
+        System.out.print("사용자 UUID : ");
+        UUID userUUID = UUID.fromString(sc.nextLine());
+        us.deleteByIdUser(userUUID);
+    }
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.entity.Channel;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ChannelService {
+    public void createChannel(String channelname,String description);
+    public Channel readByIdChannel(UUID name);
+    public void readAllChannel();
+    public void updateChannel(UUID channelUUID,String channelname,String description);
+    public void deleteByIdChannel(UUID channelUUID);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.service;
+
+
+import com.sprint.mission.discodeit.entity.Message;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MessageService {
+    public Message createMessage(UUID userId, UUID channelId, String content);
+    public Message readByIdMessage(UUID message);
+    public void readAllMessage();
+    public void updateMessage(UUID messageUUID, String content);
+    public void deleteByIdMessage(UUID message);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/UserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserService.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserService {
+    public void createUser(String username,String password );
+    public User readByIdUser(UUID name);
+    public void readAllUser();
+    public void updateUser(UUID user, String username,String password );
+    public void deleteByIdUser(UUID user);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFChannelService.java
@@ -1,0 +1,60 @@
+package com.sprint.mission.discodeit.service.jcf;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.service.ChannelService;
+
+
+import java.util.*;
+
+public class JCFChannelService implements ChannelService {
+    final Map<UUID, Channel> data = new HashMap<>();
+
+    @Override
+    public void createChannel(String channelname, String description) {
+        Channel channel = new Channel(channelname, description);
+        data.put(channel.getId(),channel);
+
+    }
+
+    @Override
+    public Channel readByIdChannel(UUID name) {
+       return data.entrySet().stream()
+               .filter(entry->entry.getKey().equals(name))
+               .map(entry->entry.getValue())
+               .findFirst().orElse(null);
+    }
+
+    @Override
+    public void readAllChannel() {
+        data.entrySet().stream()
+                .forEach(entry->
+                        System.out.println(entry.getKey()+" "+entry.getValue()));
+    }
+
+    @Override
+    public void updateChannel(UUID channelUUID,String channelname, String description) {
+        for(Map.Entry<UUID,Channel>entry:data.entrySet()){
+            UUID channelID = entry.getKey();
+            Channel channel = entry.getValue();
+            if(channelID.equals(channelUUID)){
+                channel.update(channelname,description);
+                System.out.println("수정 성공하였습니다.");
+                return;
+            }
+        }
+        System.out.println("수정 실패하였습니다.");
+    }
+
+    @Override
+    public void deleteByIdChannel(UUID channelUUID) {
+        for(Map.Entry<UUID,Channel>entry:data.entrySet()){
+            UUID channelID = entry.getKey();
+            if(channelID.equals(channelUUID)){
+                data.remove(channelID);
+                System.out.println("삭제 성공하였습니다.");
+                return;
+            }
+        }
+        System.out.println("삭제 실패하였습니다.");
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFMessageService.java
@@ -1,0 +1,61 @@
+package com.sprint.mission.discodeit.service.jcf;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.service.MessageService;
+
+import java.util.*;
+
+public class JCFMessageService implements MessageService {
+    final Map<UUID, Message> data= new HashMap<>();
+
+    @Override
+    public Message createMessage(UUID userId, UUID channelId, String content) {
+        Message message = new Message(userId, channelId,content);
+        data.put(message.getId(),message);
+        return message;
+    }
+
+    @Override
+    public Message readByIdMessage(UUID message) {
+        return data.entrySet().stream()
+                .filter(entry->entry.getKey().equals(message))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public void readAllMessage() {
+        data.entrySet().stream()
+                .forEach(entry->
+                        System.out.println(entry.getKey()+" "+entry.getValue()));
+    }
+
+    @Override
+    public void updateMessage(UUID messageUUID, String content) {
+        for(Map.Entry<UUID,Message>entry:data.entrySet()){
+            UUID messageId = entry.getKey();
+            Message message = entry.getValue();
+            if(messageId.equals(messageUUID)){
+                message.update(content);
+                System.out.println("수정 성공하였습니다.");
+                return;
+            }
+        }
+        System.out.println("수정 실패하였습니다.");
+    }
+
+    @Override
+    public void deleteByIdMessage(UUID message) {
+        for(Map.Entry<UUID,Message>entry:data.entrySet()){
+            UUID messageID = entry.getKey();
+            if(messageID.equals(message)){
+                data.remove(messageID);
+                System.out.println("삭제 성공하였습니다.");
+                return;
+            }
+        }
+        System.out.println("삭제 실패하였습니다.");
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFUserService.java
@@ -1,0 +1,61 @@
+package com.sprint.mission.discodeit.service.jcf;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.service.UserService;
+
+
+import java.util.*;
+
+public class JCFUserService implements UserService {
+    final Map<UUID, User> data= new HashMap<>();
+
+    @Override
+    public void createUser(String username, String password) {
+        User user=new User(username, password);
+        data.put(user.getId(),user);
+    }
+
+    @Override
+    public User readByIdUser(UUID name) {
+        return data.entrySet().stream()
+                .filter(entry->entry.getKey().equals(name))
+                .map(Map.Entry::getValue)
+                .findFirst().orElse(null);
+    }
+
+    @Override
+    public void readAllUser() {
+       data.entrySet().stream()
+               .forEach(entry->
+                       System.out.println(entry.getKey()+" "+entry.getValue()));
+
+    }
+
+    @Override
+    public void updateUser(UUID name, String username, String password) {
+        for(Map.Entry<UUID,User>entry : data.entrySet()){
+            UUID id = entry.getKey();
+            User user = entry.getValue();
+            if(id.equals(name)){
+                user.update(username,password);
+                System.out.println("수정 성공하였습니다.");
+                return;
+            }
+        }
+        System.out.println("수정 실패하였습니다.");
+    }
+
+    @Override
+    public void deleteByIdUser(UUID user) {
+        for(Map.Entry<UUID, User>entry:data.entrySet()){
+            UUID userID = entry.getKey();
+            if(userID.equals(user)){
+                data.remove(userID);
+                System.out.println("삭제 성공하였습니다.");
+                return;
+            }
+        }
+        System.out.println("삭제 실패하였습니다.");
+    }
+}


### PR DESCRIPTION
## 요구사항
도메인 모델 설계
User,Channel,Message
- 공통 : id,createdAt,updateAt(생성자 초기화)
- 나머지 생성자 파라미터를 통해 초기화
- 메소드 : Getter, 수정은 update

서비스 설계
- 서비스 인터페이스 네이밍 : JCF[도메인 모델 이름]
- Collection을 final로 선언하여 data에서 생성, 조회, 수정, 삭제 메소드 구현
### 기본
- [x] 도메인 모델 구현
- [x ] 서비스 인터페이스 설계 및 구현(각 도메인 모델별 CRUD/ JCF메모리 기반)
- [x] 메인 클래스 구현 (등록, 조회(단건,다건),수정,삭제)

### 심화
- [x] 서비스간 의존성 주입
- readId함수의 리턴타입을 도메인 객체로 받아 메시지를 등록할 때 사용자의 UUID와 채널의 UUID의 일치여부를 보고 생성

## 주요 사항
- 조회, 수정, 삭제, 메시지 등록 기능을 사용하려면 사용자의 UUID와 채널의 UUID를 미리 알아야 한다. 
- 채널 등록과 사용자 등록을 한 후 먼저 조회 - 다건으로 가서 UUID를 확인해야 한다.
- 그리도 UUID를 입력받을때 UUID 형식이 아니면 에러가 난다.


## 스크린샷
<img width="345" height="266" alt="image" src="https://github.com/user-attachments/assets/2b4592fa-9ada-48f3-8b02-3f2b9e753c1a" />
<img width="336" height="330" alt="image" src="https://github.com/user-attachments/assets/561087c0-c65f-475c-af5b-f8eedd3078bb" />
<img width="296" height="335" alt="image" src="https://github.com/user-attachments/assets/615efffa-a003-4235-a114-641f2c22bdb3" />
<img width="244" height="200" alt="image" src="https://github.com/user-attachments/assets/1e814e81-1814-46ed-8dd1-7a1ec0ead85f" />
<img width="212" height="215" alt="image" src="https://github.com/user-attachments/assets/3764afea-7805-4665-bc27-3fa616b97501" />

## 멘토에게
- 조회, 수정, 삭제 모두 UUID를 알아야만 할 수 있도록 구성하였는데 이렇게 하는 것이 맞는지 궁금합니다. 유일한 닉네임을 받자니 이미 UUID가 있어서 중복이 가능하도록 만들었고 사용자가 힘들더라도 UUID로 받도록 구성하였습니다.
- readId함수가 엔티티의 객체를 그냥 가져오도록 만들어서 메인에서 모든 일이 가능하게 되었습니다. 이렇게 만드는 것이 맞는지 궁금합니다. 그렇다고 너무 void로 받으니 출력 말고 할 일이 없는 기능이 된 거 같아서 아쉽습니다.
- 메인클래스와 서비스 클래스의 역할 경계가 어디까지 인지 궁금합니다.

