### PR TITLE
[박문아] sprint2

### DIFF
--- a/src/main/java/com/sprint/mission/discodeit/entity/BaseEntity.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BaseEntity.java
@@ -8,9 +8,9 @@ import java.util.UUID;
 public abstract class BaseEntity implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
-    private UUID id;
-    private long createdAt;
-    private long updatedAt;
+    protected UUID id;
+    protected long createdAt;
+    protected long updatedAt;
 
     //기본생성자
     public BaseEntity() {

--- a/src/main/java/com/sprint/mission/discodeit/entity/BaseEntity.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BaseEntity.java
@@ -1,8 +1,13 @@
 package com.sprint.mission.discodeit.entity;
 
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
 import java.util.UUID;
 
-public abstract class BaseEntity {
+public abstract class BaseEntity implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
     private UUID id;
     private long createdAt;
     private long updatedAt;
@@ -26,7 +31,7 @@ public abstract class BaseEntity {
     public long getUpdatedAt() {
         return updatedAt;
     }
-    public void update(){ //파라미터 추가 필요
+    public void updateTimestamp(){
         this.updatedAt=System.currentTimeMillis();
     }
 
@@ -38,5 +43,17 @@ public abstract class BaseEntity {
         sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
         return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        BaseEntity that = (BaseEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
@@ -1,9 +1,13 @@
 package com.sprint.mission.discodeit.entity;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Channel extends BaseEntity {
+public class Channel extends BaseEntity implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
     private String channelName; //채널명
     private String description; //채널 이름
 
@@ -23,7 +27,7 @@ public class Channel extends BaseEntity {
 
 
     public void update(String channelName, String description){
-        super.update();
+        super.updateTimestamp();
         this.description=description;
         this.channelName=channelName;
     }
@@ -31,9 +35,10 @@ public class Channel extends BaseEntity {
     @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("Channel{");
-        sb.append("channelName='").append(channelName).append('\'');
+        sb.append(super.getId());
+        sb.append(" channelName='").append(channelName).append('\'');
         sb.append(", description='").append(description);
-        sb.append('}');
+        sb.append("'}");
         return sb.toString();
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/Message.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Message.java
@@ -1,8 +1,13 @@
 package com.sprint.mission.discodeit.entity;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.UUID;
 
-public class Message extends BaseEntity {
+public class Message extends BaseEntity implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     private UUID userId;
     private UUID channelId;
     private String content;
@@ -26,17 +31,18 @@ public class Message extends BaseEntity {
         return content;
     }
     public void update(String content){
-        super.update();
+        super.updateTimestamp();
         this.content=content;
     }
 
     @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("Message{");
-        sb.append("userId=").append(userId);
+        sb.append(super.getId());
+        sb.append(" userId=").append(userId);
         sb.append(", channelId=").append(channelId);
         sb.append(", content='").append(content).append('\'');
-        sb.append('}');
+        sb.append("'}");
         return sb.toString();
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/User.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/User.java
@@ -1,10 +1,15 @@
 package com.sprint.mission.discodeit.entity;
 
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class User extends BaseEntity {
+public class User extends BaseEntity implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     private String username;
     private String password;
 
@@ -24,7 +29,7 @@ public class User extends BaseEntity {
 
 
     public void update(String username,String password){
-        super.update();
+        super.updateTimestamp();
         this.username=username;
         this.password=password;
     }
@@ -33,9 +38,10 @@ public class User extends BaseEntity {
     public String toString() {
         final StringBuffer sb = new StringBuffer("User{");
         sb.append(super.getId());
-        sb.append("username='").append(username).append('\'');
+        sb.append(" username='").append(username).append('\'');
         sb.append(", password='").append(password);
-        sb.append('}');
+        sb.append("'}");
         return sb.toString();
     }
+
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/ChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/ChannelRepository.java
@@ -1,0 +1,24 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ChannelRepository {
+    Channel save(Channel channel);
+
+    Optional<Channel> findById(UUID id);
+
+    List<Channel> findAll();
+
+    long count();
+
+    boolean delete(UUID id);
+
+    boolean existsById(UUID id);
+
+    boolean update(UUID channelUUID, String channelname, String description);
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
@@ -1,0 +1,24 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MessageRepository{
+    Message save(Message message);
+
+    Optional<Message> findById(UUID id);
+
+    List<Message> findAll();
+
+    long count();
+
+    boolean delete(UUID id);
+
+    boolean existsById(UUID id);
+
+    boolean update(UUID messageUUID,String content);
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
@@ -1,0 +1,23 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository {
+    User save(User user);
+
+    Optional<User> findById(UUID id);
+
+    List<User> findAll();
+
+    long count();
+
+    boolean delete(UUID id);
+
+    boolean existsById(UUID id);
+
+    boolean update(UUID id,String username, String password);
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
@@ -110,8 +110,12 @@ public class FileChannelRepository implements ChannelRepository {
             e.printStackTrace();
             return false;
         }
-
-        channel.update(channelname, description);
+        if(channel.getChannelName().equals(channelname) && channel.getDescription().equals(description)){
+            System.out.println("수정 전과 일치합니다.");
+            return false;
+        }else {
+            channel.update(channelname, description);
+        }
         try (FileOutputStream fos = new FileOutputStream(file);
              ObjectOutputStream oos = new ObjectOutputStream(fos);){
             oos.writeObject(channel);

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
@@ -1,0 +1,125 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class FileChannelRepository implements ChannelRepository {
+    private final String DIRECTORY;
+    private final String EXTENSION;
+
+    public FileChannelRepository(){
+        DIRECTORY = "CHANNEL";
+        EXTENSION = ".ser";
+        Path path = Paths.get(DIRECTORY);
+        if(!path.toFile().exists()){
+            try {
+                Files.createDirectory(path);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public Channel save(Channel channel) {
+        Path path = new File(DIRECTORY,channel.getId()+EXTENSION).toPath();
+        try (FileOutputStream fos = new FileOutputStream(path.toFile());
+             ObjectOutputStream oos = new ObjectOutputStream(fos)){
+            oos.writeObject(channel);
+            return channel;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+
+        }
+    }
+
+    @Override
+    public Optional<Channel> findById(UUID id) {
+        Path path = Paths.get(DIRECTORY,id+EXTENSION);
+        Optional<Channel> channel = Optional.empty();
+        try (FileInputStream fis = new FileInputStream(path.toFile());
+             ObjectInputStream ois = new ObjectInputStream(fis);) {
+            channel = Optional.of((Channel)ois.readObject());
+            return channel;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<Channel> findAll() {
+        List<Channel> channelList = new ArrayList<>();
+        File file = new File(DIRECTORY);
+        File[] folder = file.listFiles((dir,name)->name.endsWith(EXTENSION));
+        if(folder==null){return channelList;}
+        for(File f:folder) {
+            try (FileInputStream fis = new FileInputStream(f);
+                 ObjectInputStream ois = new ObjectInputStream(fis)) {
+                channelList.add((Channel)ois.readObject());
+
+            } catch (Exception e) {
+                e.printStackTrace();
+
+            }
+        }
+        return channelList;
+    }
+
+    @Override
+    public long count() {
+        File folder = new File(DIRECTORY);
+        File[] file = folder.listFiles((dir,name)-> name.endsWith(EXTENSION));
+        if(file== null) return 0;
+
+        return file.length;
+    }
+
+    @Override
+    public boolean delete(UUID id) {
+        File file = new File(DIRECTORY,id+EXTENSION);
+        return file.delete();
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        Path path = Paths.get(DIRECTORY,id+EXTENSION);
+        return Files.exists(path);
+    }
+
+    @Override
+    public boolean update(UUID channelUUID, String channelname, String description) {
+        File file = new File(DIRECTORY, channelUUID + EXTENSION);
+        Channel channel;
+        try (FileInputStream fis = new FileInputStream(file);
+             ObjectInputStream ois = new ObjectInputStream(fis);
+        ) {
+            channel = (Channel)ois.readObject();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        channel.update(channelname, description);
+        try (FileOutputStream fos = new FileOutputStream(file);
+             ObjectOutputStream oos = new ObjectOutputStream(fos);){
+            oos.writeObject(channel);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+    
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
@@ -1,0 +1,124 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class FileMessageRepository implements MessageRepository {
+    private final String DIRECTORY;
+    private final String EXTENSION;
+
+    public FileMessageRepository(){
+        DIRECTORY = "MESSAGE";
+        EXTENSION = ".ser";
+        Path path = Paths.get(DIRECTORY);
+        if(!path.toFile().exists()){
+            try {
+                Files.createDirectory(path);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+    @Override
+    public Message save(Message message) {
+        Path path = new File(DIRECTORY,message.getId()+EXTENSION).toPath();
+        try (FileOutputStream fos = new FileOutputStream(path.toFile());
+        ObjectOutputStream oos = new ObjectOutputStream(fos)){
+            oos.writeObject(message);
+            return message;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+
+        }
+    }
+
+    @Override
+    public Optional<Message> findById(UUID id) {
+        Path path = Paths.get(DIRECTORY,id+EXTENSION);
+        Optional<Message> message = Optional.empty();
+        try (FileInputStream fis = new FileInputStream(path.toFile());
+             ObjectInputStream ois = new ObjectInputStream(fis);) {
+            message = Optional.of((Message)ois.readObject());
+            return message;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<Message> findAll() {
+        List<Message> messageList = new ArrayList<>();
+        File file = new File(DIRECTORY);
+        File[] folder = file.listFiles((dir,name)->name.endsWith(EXTENSION));
+        if(folder==null){return messageList;}
+        for(File f:folder) {
+            try (FileInputStream fis = new FileInputStream(f);
+                 ObjectInputStream ois = new ObjectInputStream(fis)) {
+                messageList.add((Message)ois.readObject());
+
+            } catch (Exception e) {
+                e.printStackTrace();
+
+            }
+        }
+        return messageList;
+    }
+
+    @Override
+    public long count() {
+        File folder = new File(DIRECTORY);
+        File[] file = folder.listFiles((dir,name)-> name.endsWith(EXTENSION));
+        if(file== null) return 0;
+
+        return file.length;
+
+    }
+
+    @Override
+    public boolean delete(UUID id) {
+        File file = new File(DIRECTORY,id+EXTENSION);
+        return file.delete();
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        Path path = Paths.get(DIRECTORY,id+EXTENSION);
+        return Files.exists(path);
+    }
+
+    @Override
+    public boolean update(UUID messageId,String content) {
+        File file = new File(DIRECTORY, messageId + EXTENSION);
+        Message message;
+        try (FileInputStream fis = new FileInputStream(file);
+             ObjectInputStream ois = new ObjectInputStream(fis);
+        ) {
+            message = (Message)ois.readObject();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        message.update(content);
+        try (FileOutputStream fos = new FileOutputStream(file);
+             ObjectOutputStream oos = new ObjectOutputStream(fos);){
+            oos.writeObject(message);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
@@ -109,8 +109,13 @@ public class FileMessageRepository implements MessageRepository {
             e.printStackTrace();
             return false;
         }
+        if(message.getContent().equals(content)){
+            System.out.println("수정 전과 일치합니다.");
+            return false;
+        }else{
+            message.update(content);
+        }
 
-        message.update(content);
         try (FileOutputStream fos = new FileOutputStream(file);
              ObjectOutputStream oos = new ObjectOutputStream(fos);){
             oos.writeObject(message);

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
@@ -108,8 +108,12 @@ public class FileUserRepository implements UserRepository {
             e.printStackTrace();
             return false;
         }
-
-        user.update(username,password);
+        if(user.getUsername().equals(username) && user.getPassword().equals(password)){
+            System.out.println("수정 전과 일치합니다.");
+            return false;
+        }else {
+            user.update(username, password);
+        }
         try (FileOutputStream fos = new FileOutputStream(file);
              ObjectOutputStream oos = new ObjectOutputStream(fos);){
             oos.writeObject(user);

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
@@ -1,0 +1,122 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class FileUserRepository implements UserRepository {
+    private final String DIRECTORY;
+    private final String EXTENSION;
+
+    public FileUserRepository(){
+        DIRECTORY ="USER";
+        EXTENSION =".ser";
+        Path path = Paths.get(DIRECTORY);
+        if(!path.toFile().exists()) {
+            try {
+                Files.createDirectory(path);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+    @Override
+    public User save(User user) {
+        Path path = new File(DIRECTORY,user.getId()+EXTENSION).toPath();
+        try (FileOutputStream fos = new FileOutputStream(path.toFile());
+             ObjectOutputStream oos = new ObjectOutputStream(fos)) {
+            oos.writeObject(user);
+            return user;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        User user = null;
+        Path path = Paths.get(DIRECTORY, id + EXTENSION);
+        try(FileInputStream fis = new FileInputStream(path.toFile());
+            ObjectInputStream ois = new ObjectInputStream(fis);) {
+            user=(User)ois.readObject();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+        return Optional.ofNullable(user);
+    }
+
+    @Override
+    public List<User> findAll() {
+        List<User> userList = new ArrayList<>();
+        File file = new File(DIRECTORY);
+        File[] folder = file.listFiles((dir, name)->name.endsWith(EXTENSION));
+
+        if(folder==null){return userList;}
+
+        for(File f:folder){
+            try (FileInputStream fis = new FileInputStream(f);
+            ObjectInputStream ois = new ObjectInputStream(fis)) {
+                userList.add((User)ois.readObject());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return userList;
+
+    }
+
+    @Override
+    public long count() {
+        File folder =  new File(DIRECTORY);
+        File[] files = folder.listFiles((dir,name)->name.endsWith(EXTENSION));
+        if(files==null) return 0;
+        ;
+        return files.length;
+    }
+
+    @Override
+    public boolean delete(UUID id) {
+        File file =new File(DIRECTORY, id + EXTENSION);
+        return file.delete();
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        File file = new File(DIRECTORY, id + EXTENSION);
+        return file.isFile();
+    }
+
+    @Override
+    public boolean update(UUID UserId, String username, String password) {
+        File file = new File(DIRECTORY, UserId + EXTENSION);
+        User user;
+        try (FileInputStream fis = new FileInputStream(file);
+        ObjectInputStream ois = new ObjectInputStream(fis);
+        ) {
+            user = (User)ois.readObject();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        user.update(username,password);
+        try (FileOutputStream fos = new FileOutputStream(file);
+             ObjectOutputStream oos = new ObjectOutputStream(fos);){
+            oos.writeObject(user);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFChannelRepository.java
@@ -1,7 +1,6 @@
 package com.sprint.mission.discodeit.repository.jcf;
 
 import com.sprint.mission.discodeit.entity.Channel;
-import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 
 import java.util.*;

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFChannelRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFChannelRepository.java
@@ -1,0 +1,56 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+
+import java.util.*;
+
+public class JCFChannelRepository implements ChannelRepository {
+    final Map<UUID, Channel> data;
+    public JCFChannelRepository() {
+        data = new HashMap<>();
+    }
+    @Override
+    public Channel save(Channel channel) {
+        data.put(channel.getId(), channel);
+        return channel;
+    }
+
+    @Override
+    public Optional<Channel> findById(UUID id) {
+        return Optional.ofNullable(data.get(id));
+    }
+
+    @Override
+    public List<Channel> findAll() {
+        return new ArrayList<>(data.values());
+    }
+
+    @Override
+    public long count() {
+        return data.size();
+    }
+
+    @Override
+    public boolean delete(UUID id) {
+        return  data.remove(id) != null;
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return data.containsKey(id);
+    }
+
+    @Override
+    public boolean update(UUID channelUUID, String channelname, String description) {
+        Channel channel = data.get(channelUUID);
+        if(channel.getChannelName().equals(channelname) && channel.getDescription().equals(description)){
+            System.out.println("수정 전과 일치합니다.");
+            return false;
+        }
+
+        channel.update(channelname, description);
+        return true;
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFMessageRepository.java
@@ -1,0 +1,57 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+
+import java.util.*;
+
+public class JCFMessageRepository implements MessageRepository {
+    final Map<UUID, Message> data;
+    public JCFMessageRepository() {
+        data = new HashMap<>();
+    }
+    @Override
+    public Message save(Message message) {
+        data.put(message.getId(), message);
+        return message;
+    }
+
+    @Override
+    public Optional<Message> findById(UUID id) {
+        return Optional.ofNullable(data.get(id));
+    }
+
+    @Override
+    public List<Message> findAll() {
+        return new ArrayList<>(data.values());
+    }
+
+    @Override
+    public long count() {
+        return data.size();
+    }
+
+    @Override
+    public boolean delete(UUID id) {
+        return  data.remove(id) != null;
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return data.containsKey(id);
+    }
+
+    @Override
+    public boolean update(UUID messageUUID, String content) {
+        Message message = data.get(messageUUID);
+        if(message.getContent().equals(content)){
+            System.out.println("수정 전과 일치합니다.");
+            return false;
+        }
+
+        message.update(content);
+        return true;
+    }
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFUserRepository.java
@@ -1,0 +1,56 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+
+import java.util.*;
+
+public class JCFUserRepository implements UserRepository {
+    final Map<UUID, User> data;
+    public JCFUserRepository() {
+        data = new HashMap<>();
+    }
+
+    @Override
+    public User save(User user) {
+        data.put(user.getId(), user);
+        return user;
+    }
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        return Optional.ofNullable(data.get(id));
+    }
+
+    @Override
+    public List<User> findAll() {
+        return new ArrayList<>(data.values());
+    }
+
+    @Override
+    public long count() {
+        return data.size();
+    }
+
+    @Override
+    public boolean delete(UUID id) {
+        return  data.remove(id) != null;
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return data.containsKey(id);
+    }
+
+    @Override
+    public boolean update(UUID id, String username, String password) {
+        User user = data.get(id);
+        if(user.getUsername().equals(username) && user.getPassword().equals(password)){
+            System.out.println("수정 전과 일치합니다.");
+            return false;
+        }
+
+        user.update(username, password);
+        return true;
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/run/JavaApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/run/JavaApplication.java
@@ -3,6 +3,18 @@ package com.sprint.mission.discodeit.run;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.jcf.JCFChannelRepository;
+import com.sprint.mission.discodeit.repository.jcf.JCFMessageRepository;
+import com.sprint.mission.discodeit.repository.jcf.JCFUserRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.MessageService;
+import com.sprint.mission.discodeit.service.UserService;
+import com.sprint.mission.discodeit.service.basic.BasicChannelService;
+import com.sprint.mission.discodeit.service.basic.BasicMessageService;
+import com.sprint.mission.discodeit.service.basic.BasicUserService;
+import com.sprint.mission.discodeit.service.file.FileChannelService;
+import com.sprint.mission.discodeit.service.file.FileMessageService;
+import com.sprint.mission.discodeit.service.file.FileUserService;
 import com.sprint.mission.discodeit.service.jcf.JCFChannelService;
 import com.sprint.mission.discodeit.service.jcf.JCFMessageService;
 import com.sprint.mission.discodeit.service.jcf.JCFUserService;
@@ -12,13 +24,37 @@ import java.util.Scanner;
 import java.util.UUID;
 
 public class JavaApplication {
-    private static final JCFChannelService cs = new JCFChannelService();
-    private static final JCFUserService us = new JCFUserService();
-    private static final JCFMessageService ms = new JCFMessageService();
+    private  final ChannelService channelService;
+    private final UserService userService;
+    private final MessageService messageService;
     private static final Scanner sc = new Scanner(System.in);
 
+    public JavaApplication(String type) {
+        switch (type.toLowerCase()) {
+            case "jcf":
+                this.userService = new JCFUserService();
+                this.channelService = new JCFChannelService();
+                this.messageService = new JCFMessageService();
+                break;
+            case "file":
+                this.userService = new FileUserService();
+                this.channelService = new FileChannelService();
+                this.messageService = new FileMessageService();
+                break;
+            case "basic":
+                this.userService = new BasicUserService(new JCFUserRepository()); // 예시
+                this.channelService = new BasicChannelService(new JCFChannelRepository());
+                this.messageService = new BasicMessageService(new JCFMessageRepository());
+                break;
+            default:
+                throw new IllegalArgumentException("지원하지 않는 구현체 타입: " + type);
+        }
+    }
+
     public static void main(String[] args) {
-        JavaApplication app = new JavaApplication();
+        System.out.println("사용할 구현체를 입력하세요 (jcf / file / basic):");
+        String type = sc.nextLine();
+        JavaApplication app = new JavaApplication(type);
         app.mainMenu();
     }
 
@@ -137,18 +173,18 @@ public class JavaApplication {
             System.out.println("3. 수정 - 메시지");
             System.out.println("9. 전 페이지로");
             System.out.print("메뉴 번호 입력 >> ");
-            int num =Integer.parseInt(sc.nextLine());
+            String num =sc.nextLine();
             switch (num){
-                case 1:
+                case "1":
                     updateChannel();
                     continue;
-                case 2:
+                case "2":
                     updateUser();
                     continue;
-                case 3:
+                case "3":
                     updateMessage();
                     continue;
-                case 9:
+                case "9":
                     return;
                 default:
                     System.out.println("잘못입력하였습니다. 다시 입력해주세요.");
@@ -165,18 +201,18 @@ public class JavaApplication {
             System.out.println("3. 삭제 - 메시지");
             System.out.println("9. 전 페이지로");
             System.out.print("메뉴 번호 입력 >> ");
-            int num =Integer.parseInt(sc.nextLine());
+            String num =sc.nextLine();
             switch (num){
-                case 1:
+                case "1":
                     deleteChannel();
                     continue;
-                case 2:
+                case "2":
                     deleteUser();
                     continue;
-                case 3:
+                case "3":
                     deleteMessage();
                     continue;
-                case 9:
+                case "9":
                     return;
                 default:
                     System.out.println("잘못입력하였습니다. 다시 입력해주세요.");
@@ -192,7 +228,7 @@ public class JavaApplication {
         String name=sc.nextLine();
         System.out.print("채널 내용 :");
         String description=sc.nextLine();
-        cs.createChannel(name,description);
+        channelService.createChannel(name,description);
         System.out.println("성공적으로 생성 완료하였습니다.");
     }
     public void inputUser() {
@@ -201,19 +237,31 @@ public class JavaApplication {
         String name = sc.nextLine();
         System.out.print("비밀번호 :");
         String password = sc.nextLine();
-        us.createUser(name,password);
+        userService.createUser(name,password);
     }
 
     public void inputMessage(){
         System.out.println("=== 등록 - 메시지===");
-        System.out.print("사용자 이름 :");
-        UUID name=UUID.fromString(sc.nextLine());
-        System.out.print("채널 이름 :");
-        UUID channel=UUID.fromString(sc.nextLine());
+        System.out.print("사용자 UUID :");
+        UUID name= null;
+        try {
+            name = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
+        System.out.print("채널 UUId :");
+        UUID channel= null;
+        try {
+            channel = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
         System.out.print("메시지 내용 :");
         String content=sc.nextLine();
-        if (us.readByIdUser(name) !=null && cs.readByIdChannel(channel)!=null){
-            ms.createMessage(name, channel, content);
+        if (userService.readByIdUser(name) !=null && channelService.readByIdChannel(channel)!=null){
+            messageService.createMessage(name, channel, content);
             System.out.println("메시지 등록에 성공하였습니다.");
         }else{
             System.out.println("사용자명이나 채널명이 존재하지 않습니다.");
@@ -224,8 +272,14 @@ public class JavaApplication {
     public void oneChannel(){
         System.out.println("=== 단건 - 채널 ===");
         System.out.print("채널 UUID :");
-        UUID name=UUID.fromString(sc.nextLine());
-        Channel channel=cs.readByIdChannel(name);
+        UUID name= null;
+        try {
+            name = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
+        Channel channel=channelService.readByIdChannel(name);
         if(channel!=null){
             System.out.println(channel);
         }else{
@@ -235,8 +289,14 @@ public class JavaApplication {
     public void oneUser(){
         System.out.println("=== 단건 - 사용자 ===");
         System.out.print("사용자 UUID :");
-        UUID name=UUID.fromString(sc.nextLine());
-        User user=us.readByIdUser(name);
+        UUID name= null;
+        try {
+            name = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
+        User user=userService.readByIdUser(name);
         if(user!=null){
             System.out.println(user);
         }else{
@@ -246,8 +306,14 @@ public class JavaApplication {
     public void oneMessage(){
         System.out.println("=== 단건 - 메시지 ===");
         System.out.print("메시지 UUID :");
-        UUID name=UUID.fromString(sc.nextLine());
-        Message message=ms.readByIdMessage(name);
+        UUID name= null;
+        try {
+            name = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
+        Message message=messageService.readByIdMessage(name);
         if(message!=null){
             System.out.println(message);
         }else{
@@ -257,66 +323,102 @@ public class JavaApplication {
 
     public void allChannel(){
         System.out.println("=== 다건 - 전체 채널 ===");
-        cs.readAllChannel();
+        channelService.readAllChannel();
     }
     public void allUser(){
         System.out.println("=== 다건 - 전체 사용자 ===");
-        us.readAllUser();
+        userService.readAllUser();
     }
     public void allMessage(){
         System.out.println("=== 다건 - 전체 메시지 ===");
-        ms.readAllMessage();
+        messageService.readAllMessage();
     }
 
 
     public void updateChannel(){
         System.out.println("=== 수정 - 채널 ===");
         System.out.print("채널 UUID : ");
-        UUID channelUUID = UUID.fromString(sc.nextLine());
+        UUID channelUUID = null;
+        try {
+            channelUUID = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
         System.out.print("채널 이름 :");
         String channelName = sc.nextLine();
         System.out.print("채널 설명 : ");
         String description = sc.nextLine();
-        cs.updateChannel(channelUUID,channelName,description);
+        channelService.updateChannel(channelUUID,channelName,description);
     }
 
     public void updateUser(){
         System.out.println("=== 수정 - 사용자 ===");
         System.out.print("사용자 UUID : ");
-        UUID userUUID = UUID.fromString(sc.nextLine());
+        UUID userUUID = null;
+        try {
+            userUUID = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
         System.out.print("사용자 이름 :");
         String userName = sc.nextLine();
         System.out.print("비밀번호 : ");
         String password = sc.nextLine();
-        us.updateUser(userUUID,userName, password);
+        userService.updateUser(userUUID,userName, password);
 
     }
     public void updateMessage(){
         System.out.println("=== 수정 - 메시지 ===");
         System.out.print("메시지 UUID : ");
-        UUID messageUUID = UUID.fromString(sc.nextLine());
+        UUID messageUUID = null;
+        try {
+            messageUUID = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
         System.out.print("메시지 내용 :");
         String content = sc.nextLine();
-        ms.updateMessage(messageUUID, content);
+        messageService.updateMessage(messageUUID, content);
     }
 
     public void deleteChannel(){
         System.out.println("=== 삭제 - 채널 ===");
         System.out.print("채널 UUID : ");
-        UUID channelUUID = UUID.fromString(sc.nextLine());
-        cs.deleteByIdChannel(channelUUID);
+        UUID channelUUID = null;
+        try {
+            channelUUID = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
+        channelService.deleteByIdChannel(channelUUID);
     }
     public void deleteMessage(){
         System.out.println("=== 삭제 - 메시지 ===");
         System.out.print("메시지 UUID : ");
-        UUID messageUUID = UUID.fromString(sc.nextLine());
-        ms.deleteByIdMessage(messageUUID);
+        UUID messageUUID = null;
+        try {
+            messageUUID = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
+        messageService.deleteByIdMessage(messageUUID);
     }
     public void deleteUser(){
         System.out.println("=== 삭제 - 사용자 ===");
         System.out.print("사용자 UUID : ");
-        UUID userUUID = UUID.fromString(sc.nextLine());
-        us.deleteByIdUser(userUUID);
+        UUID userUUID = null;
+        try {
+            userUUID = UUID.fromString(sc.nextLine());
+        } catch (IllegalArgumentException e) {
+            System.out.println("올바른 UUID 형식을 입력해주세요");
+            return;
+        }
+        userService.deleteByIdUser(userUUID);
     }
 
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -1,39 +1,35 @@
-package com.sprint.mission.discodeit.service.jcf;
+package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.entity.Channel;
-import com.sprint.mission.discodeit.entity.Message;
-import com.sprint.mission.discodeit.entity.User;
-import com.sprint.mission.discodeit.repository.jcf.JCFChannelRepository;
-import com.sprint.mission.discodeit.repository.jcf.JCFUserRepository;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.service.ChannelService;
 
+import java.util.List;
+import java.util.UUID;
 
-import java.util.*;
+public class BasicChannelService implements ChannelService {
+    private final ChannelRepository cr;
 
-public class JCFChannelService implements ChannelService {
-    private final JCFChannelRepository jcr;
-
-    public JCFChannelService() {
-        this.jcr = new JCFChannelRepository();
+    public BasicChannelService(ChannelRepository channelRepository) {
+        this.cr = channelRepository;
     }
-
 
     @Override
     public void createChannel(String channelname, String description) {
         Channel channel = new Channel(channelname, description);
-        Channel channelresult = jcr.save(channel);
+        Channel channelresult = cr.save(channel);
         System.out.println(channelresult.toString());
     }
 
     @Override
     public Channel readByIdChannel(UUID name) {
-        return jcr.findById(name).orElse(null);
+        return cr.findById(name).orElse(null);
     }
 
     @Override
     public void readAllChannel() {
-        List<Channel> channelList = jcr.findAll();
-        long num = jcr.count();
+        List<Channel> channelList = cr.findAll();
+        long num = cr.count();
         if(num>0){
             System.out.println("현재 등록된 채널은 "+num+"명 입니다.");
             for(Channel channel : channelList){
@@ -46,8 +42,8 @@ public class JCFChannelService implements ChannelService {
 
     @Override
     public void updateChannel(UUID channelUUID, String channelname, String description) {
-        if(jcr.existsById(channelUUID)){
-            if(jcr.update(channelUUID,channelname,description)){
+        if(cr.existsById(channelUUID)){
+            if(cr.update(channelUUID,channelname,description)){
                 System.out.println("수정 성공하였습니다.");
             }else{
                 System.out.println("수정 실패하였습니다.");
@@ -59,8 +55,8 @@ public class JCFChannelService implements ChannelService {
 
     @Override
     public void deleteByIdChannel(UUID channelUUID) {
-        if(jcr.existsById(channelUUID)) {
-            if (jcr.delete(channelUUID)) {
+        if(cr.existsById(channelUUID)) {
+            if (cr.delete(channelUUID)) {
                 System.out.println("삭제 성공하였습니다.");
             } else {
                 System.out.println("삭제 실패하였습니다.");

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -1,37 +1,34 @@
-package com.sprint.mission.discodeit.service.jcf;
+package com.sprint.mission.discodeit.service.basic;
 
-import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.Message;
-import com.sprint.mission.discodeit.entity.User;
-import com.sprint.mission.discodeit.repository.jcf.JCFChannelRepository;
-import com.sprint.mission.discodeit.repository.jcf.JCFMessageRepository;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.service.MessageService;
 
-import java.util.*;
+import java.util.List;
+import java.util.UUID;
 
-public class JCFMessageService implements MessageService {
-    private final JCFMessageRepository jmr;
+public class BasicMessageService implements MessageService {
+    private final MessageRepository mr;
 
-    public JCFMessageService() {
-        this.jmr = new JCFMessageRepository();
+    public BasicMessageService(MessageRepository messageRepository) {
+        this.mr = messageRepository;
     }
-
     @Override
     public Message createMessage(UUID userId, UUID channelId, String content) {
-        //main에서 userId, channelId 일치 확인하고 시작
         Message message = new Message(userId, channelId,content);
-        return jmr.save(message);
+        return mr.save(message);
     }
 
     @Override
     public Message readByIdMessage(UUID message) {
-        return  jmr.findById(message).orElse(null);
+        return  mr.findById(message).orElse(null);
     }
 
     @Override
     public void readAllMessage() {
-        List<Message> messageList = jmr.findAll();
-        long num = jmr.count();
+        List<Message> messageList = mr.findAll();
+        long num = mr.count();
         if(num>0){
             System.out.println("현재 등록된 메시지는 "+num+"개 입니다.");
             for(Message message : messageList){
@@ -44,8 +41,8 @@ public class JCFMessageService implements MessageService {
 
     @Override
     public void updateMessage(UUID messageUUID, String content) {
-        if(jmr.existsById(messageUUID)){
-            if(jmr.update(messageUUID,content)){
+        if(mr.existsById(messageUUID)){
+            if(mr.update(messageUUID,content)){
                 System.out.println("수정 성공하였습니다.");
             }else{
                 System.out.println("수정 실패하였습니다.");
@@ -57,8 +54,8 @@ public class JCFMessageService implements MessageService {
 
     @Override
     public void deleteByIdMessage(UUID message) {
-        if(jmr.existsById(message)) {
-            if (jmr.delete(message)) {
+        if(mr.existsById(message)) {
+            if (mr.delete(message)) {
                 System.out.println("삭제 성공하였습니다.");
             } else {
                 System.out.println("삭제 실패하였습니다.");
@@ -68,3 +65,4 @@ public class JCFMessageService implements MessageService {
         }
     }
 }
+

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -1,0 +1,69 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.UserService;
+
+import java.util.List;
+import java.util.UUID;
+
+public class BasicUserService  implements UserService {
+    private final UserRepository ur;
+
+    public BasicUserService(UserRepository userRepository) {
+        this.ur = userRepository;
+    }
+    @Override
+    public void createUser(String username, String password) {
+        User user=new User(username, password);
+        User userResult = ur.save(user);
+        System.out.println(userResult.toString());
+    }
+
+    @Override
+    public User readByIdUser(UUID name) {
+        return ur.findById(name).orElse(null);
+    }
+
+    @Override
+    public void readAllUser() {
+        List<User> userList =ur.findAll();
+        long num = ur.count();
+        if(num>0){
+            System.out.println("현재 등록된 유저는 "+num+"명 입니다.");
+            for(User user : userList){
+                System.out.println(user.toString());
+            }
+        }else{
+            System.out.println("현재 등록된 유저가 없습니다.");
+        }
+
+    }
+
+    @Override
+    public void updateUser(UUID userUUID, String username, String password) {
+        if(ur.existsById(userUUID)){
+            if(ur.update(userUUID,username,password)){
+                System.out.println("수정 성공하였습니다.");
+            }else{
+                System.out.println("수정 실패하였습니다.");
+            }
+        }else{
+            System.out.println("유저UUID가 존재하지 않습니다.");
+        }
+    }
+
+    @Override
+    public void deleteByIdUser(UUID user) {
+        if(ur.existsById(user)) {
+            if (ur.delete(user)) {
+                System.out.println("삭제 성공하였습니다.");
+            } else {
+                System.out.println("삭제 실패하였습니다.");
+            }
+        }else{
+            System.out.println("유저UUID가 존재하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/file/FileChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/file/FileChannelService.java
@@ -1,0 +1,71 @@
+package com.sprint.mission.discodeit.service.file;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.file.FileChannelRepository;
+import com.sprint.mission.discodeit.repository.file.FileMessageRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+
+import java.util.List;
+import java.util.UUID;
+
+public class FileChannelService implements ChannelService {
+    private FileChannelRepository fcr;
+    public FileChannelService() {
+        this.fcr = new FileChannelRepository();
+    }
+    @Override
+    public void createChannel(String channelname, String description) {
+        Channel channel = new Channel(channelname, description);
+        Channel channelresult = fcr.save(channel);
+        System.out.println(channelresult.toString());
+
+    }
+
+    @Override
+    public Channel readByIdChannel(UUID name) {
+        if(fcr.existsById(name)){
+            return fcr.findById(name).orElse(null);
+        }
+        System.out.println("채널 UUID가 존재하지 않습니다.");
+        return null;
+    }
+
+    @Override
+    public void readAllChannel() {
+        long num = fcr.count();
+        if(num>0) {
+            System.out.println("현재 등록된 채널은 "+num+"명 입니다.");
+            List<Channel> channelList = fcr.findAll();
+            for (Channel channel : channelList) {
+                System.out.println(channel.toString());
+            }
+        }else{
+            System.out.println("현재 등록된 유저가 없습니다.");
+        }
+    }
+
+    @Override
+    public void updateChannel(UUID channelUUID, String channelname, String description) {
+        if(fcr.existsById(channelUUID)){
+            if(fcr.update(channelUUID,channelname,description)){
+                System.out.println("사용자 수정을 성공하였습니다.");
+            }else{
+                System.out.println("사용자 수정을 실패하였습니다.");
+            }
+        }
+    }
+
+    @Override
+    public void deleteByIdChannel(UUID channelUUID) {
+        if(fcr.existsById(channelUUID)) {
+            if(fcr.delete(channelUUID)){
+                System.out.println("유저 삭제 성공!");
+            }else{
+                System.out.println("유저 삭제 실패");
+            }
+        }else{
+            System.out.println("유저UUID가 존재하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/file/FileMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/file/FileMessageService.java
@@ -1,0 +1,71 @@
+package com.sprint.mission.discodeit.service.file;
+
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.file.FileMessageRepository;
+import com.sprint.mission.discodeit.service.MessageService;
+
+import java.util.List;
+import java.util.UUID;
+
+public class FileMessageService implements MessageService {
+    private FileMessageRepository fmr;
+    public FileMessageService() {
+        this.fmr = new FileMessageRepository();
+    }
+    @Override
+    public Message createMessage(UUID userId, UUID channelId, String content) {
+        //main에서 userId, channelId 일치 확인하고 시작
+        Message message = new Message(userId, channelId, content);
+        return fmr.save(message);
+    }
+
+    @Override
+    public Message readByIdMessage(UUID message) {
+        if(fmr.existsById(message)){
+            return fmr.findById(message).orElse(null);
+        }
+        System.out.println("메시지 UUID가 존재하지 않습니다.");
+        return null;
+    }
+
+    @Override
+    public void readAllMessage() {
+        long num = fmr.count();
+        if(num>0) {
+            System.out.println("현재 등록된 메세지는 "+num+"개 입니다.");
+            List<Message> userList = fmr.findAll();
+            for (Message message : userList) {
+                System.out.println(message.toString());
+            }
+        }else{
+            System.out.println("현재 등록된 메세지가 없습니다.");
+        }
+
+    }
+
+    @Override
+    public void updateMessage(UUID messageUUID, String content) {
+        if(fmr.existsById(messageUUID)){
+            if(fmr.update(messageUUID,content)){
+                System.out.println("메세지 수정을 성공하였습니다.");
+            }else{
+                System.out.println("메세지 수정을 실패하였습니다.");
+            }
+        }
+
+    }
+
+    @Override
+    public void deleteByIdMessage(UUID message) {
+        if(fmr.existsById(message)) {
+            if(fmr.delete(message)){
+                System.out.println("메세지 삭제 성공!");
+            }else{
+                System.out.println("메세지 삭제 실패");
+            }
+        }else{
+            System.out.println("메세지UUID가 존재하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/file/FileUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/file/FileUserService.java
@@ -1,0 +1,77 @@
+package com.sprint.mission.discodeit.service.file;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.file.FileUserRepository;
+import com.sprint.mission.discodeit.service.UserService;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+
+
+public class FileUserService implements UserService {
+
+    private final FileUserRepository fur;
+    public FileUserService() {
+        this.fur = new FileUserRepository();
+    }
+    @Override
+    public void createUser(String username, String password) {
+        User user = new User(username,password);
+        User createuser = fur.save(user);
+        System.out.println(createuser.toString());
+    }
+
+    @Override
+    public User readByIdUser(UUID name) {
+        if(fur.existsById(name)) {
+            Optional<User> userOpt = fur.findById(name);
+            return userOpt.orElse(null);
+        }else{
+            System.out.println("유저UUID가 존재하지 않습니다.");
+            return null;
+        }
+    }
+
+    @Override
+    public void readAllUser() {
+        long num = fur.count();
+        if(num>0) {
+            System.out.println("현재 등록된 유저는 "+num+"명 입니다.");
+            List<User> userList = fur.findAll();
+            for (User user : userList) {
+                System.out.println(user.toString());
+            }
+        }else{
+            System.out.println("현재 등록된 유저가 없습니다.");
+        }
+    }
+
+    @Override
+    public void updateUser(UUID user, String username, String password) {
+        if(fur.existsById(user)) {
+            if(fur.update(user,username,password)) {
+                System.out.println("사용자 수정을 성공하였습니다.");
+            }else{
+                System.out.println("사용자 수정을 실패하였습니다.");
+            }
+        }else{
+            System.out.println("유저 UUID가 존재하지 않습니다.");
+        }
+    }
+
+    @Override
+    public void deleteByIdUser(UUID user) {
+        if(fur.existsById(user)) {
+            if(fur.delete(user)){
+                System.out.println("유저 삭제 성공!");
+            }else{
+                System.out.println("유저 삭제 실패");
+            }
+        }else{
+            System.out.println("유저UUID가 존재하지 않습니다.");
+        }
+
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/jcf/JCFUserService.java
@@ -2,60 +2,70 @@ package com.sprint.mission.discodeit.service.jcf;
 
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.jcf.JCFUserRepository;
 import com.sprint.mission.discodeit.service.UserService;
 
 
 import java.util.*;
 
 public class JCFUserService implements UserService {
-    final Map<UUID, User> data= new HashMap<>();
+    private final JCFUserRepository jur;
+
+
+    public JCFUserService() {
+        this.jur = new JCFUserRepository();
+    }
 
     @Override
     public void createUser(String username, String password) {
         User user=new User(username, password);
-        data.put(user.getId(),user);
+        User userResult = jur.save(user);
+        System.out.println(userResult.toString());
     }
 
     @Override
     public User readByIdUser(UUID name) {
-        return data.entrySet().stream()
-                .filter(entry->entry.getKey().equals(name))
-                .map(Map.Entry::getValue)
-                .findFirst().orElse(null);
+        return jur.findById(name).orElse(null);
     }
 
     @Override
     public void readAllUser() {
-       data.entrySet().stream()
-               .forEach(entry->
-                       System.out.println(entry.getKey()+" "+entry.getValue()));
+       List<User> userList =jur.findAll();
+       long num = jur.count();
+       if(num>0){
+           System.out.println("현재 등록된 유저는 "+num+"명 입니다.");
+           for(User user : userList){
+               System.out.println(user.toString());
+           }
+       }else{
+           System.out.println("현재 등록된 유저가 없습니다.");
+       }
 
     }
 
     @Override
-    public void updateUser(UUID name, String username, String password) {
-        for(Map.Entry<UUID,User>entry : data.entrySet()){
-            UUID id = entry.getKey();
-            User user = entry.getValue();
-            if(id.equals(name)){
-                user.update(username,password);
+    public void updateUser(UUID userUUID, String username, String password) {
+        if(jur.existsById(userUUID)){
+            if(jur.update(userUUID,username,password)){
                 System.out.println("수정 성공하였습니다.");
-                return;
+            }else{
+                System.out.println("수정 실패하였습니다.");
             }
+        }else{
+            System.out.println("유저UUID가 존재하지 않습니다.");
         }
-        System.out.println("수정 실패하였습니다.");
     }
 
     @Override
     public void deleteByIdUser(UUID user) {
-        for(Map.Entry<UUID, User>entry:data.entrySet()){
-            UUID userID = entry.getKey();
-            if(userID.equals(user)){
-                data.remove(userID);
-                System.out.println("삭제 성공하였습니다.");
-                return;
-            }
-        }
-        System.out.println("삭제 실패하였습니다.");
+       if(jur.existsById(user)) {
+           if (jur.delete(user)) {
+               System.out.println("삭제 성공하였습니다.");
+           } else {
+               System.out.println("삭제 실패하였습니다.");
+           }
+       }else{
+           System.out.println("유저UUID가 존재하지 않습니다.");
+       }
     }
 }


### PR DESCRIPTION
## 요구사항

### 기본
- [x] File IO를 통한 데이터 영속화
- [x] 서비스 구현체 분석
1. JCF는 Map이라는 Collection을 저장소로 만들고 File은 실제 드라이브에 객체를 저장하였다.
2. 새로 시작을 누르면 Map은 전의 기록이 사라지지만 File은 수동으로 지우지 않는 한 기록이 남아있다.
3. File은 디렉토리 이름으로 구분하여 파일로 저장이 가능하고 JCF은 해당 클래스내에 있는 map에 접근 해야 한다. 

- [x] 레포지토리 설계 및 구현

### 심화
- [x] 관심사 분리를 통한 레이어 간 의존성 주입
- [ ] 코드 탬플릿 이용
- [x]이전 작성한 코드(JCF 또는 File)와 비교
- 이전 작성한 코드는 Service와 Repository를 위해서 Service의 생성자에서 new로 선언하여 사용 하였지만 Basic은 메인에서 Service와 Repository를 선언함 이로 인해 메인에서 레포지토리를 쉽게 변경할 수 있으므로 테스트 하기 편리하다.
## 주요 변경사항
- 코드 탬플릿을 이용하지 않고 main 생성자에서 구현체를 선언하는 방법으로 각각의 구현체를 테스트 할 수 있습니다.
- UUID 잘 못 입력시 다시 입력하라는 답장 생겼습니다.
- 등록시 UUID를 볼 수 있습니다.
- 수정전과 수정 후가 다를 시에만 수정이 됩니다.

## 스크린샷
<img width="557" height="42" alt="image" src="https://github.com/user-attachments/assets/58864aac-fa0f-4c1f-a2e3-b50a8c480ce9" />
<img width="361" height="294" alt="image" src="https://github.com/user-attachments/assets/a3bff054-c37e-4b19-8ea6-f6c496fa9b21" />
<img width="620" height="203" alt="image" src="https://github.com/user-attachments/assets/1147895e-7559-4f57-acff-a201a94d0d3f" />


## 멘토에게
-  처음 사용할 구현체를 잘못입력하면 IllArgumentException 발생하게 하였습니다. while로 반복해서 받아 올바른 입력을 받으려고 했으나 선언 자체가 없었던 일이 되어버려 오류가 생겨 이런 방식을 체택했습니다. 이 방법이 최선인지 궁금합니다. 
- 실수 : 이미 다 만들고 제출시간이 다 되어서 서비스와 main의 역할 분리가 명확하지 않다는 점을 깨달았지만 수정하지 못하고 제출하게 되었습니다.
- 이때까지 해당 메서드를 사용 하는 곳에서 필요한 예외 출력까지 진행하였습니다. 그럼 예외 출력을 하기 위해선 리턴타입을 활용해서 main까지 넘긴 다음에 예외 출력을 해야 하는지 궁금합니다.
<img width="1120" height="350" alt="image" src="https://github.com/user-attachments/assets/352972c1-5b47-4716-af43-b6d536c133f1" />

-  모든 출력을 main에서 한다면 서비스 필요 없이 main과 레포지토리만 연결해도 괜찮을텐데 왜 이런 방식이 선호 되는지 서비스에선 main과 repository 연결만 하는지 궁금합니다