### PR TITLE
김준교 sprint3

### DIFF
--- a/5-sprint-mission3/.gitignore
+++ b/5-sprint-mission3/.gitignore
@@ -1,0 +1,196 @@
+# Created by https://www.toptal.com/developers/gitignore/api/java,windows,visualstudiocode,intellij+all,macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=java,windows,visualstudiocode,intellij+all,macos
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/java,windows,visualstudiocode,intellij+all,macos

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -1,0 +1,66 @@
+package com.sprint.mission.discodeit;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.file.FileChannelRepository;
+import com.sprint.mission.discodeit.repository.file.FileMessageRepository;
+import com.sprint.mission.discodeit.repository.file.FileUserRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import com.sprint.mission.discodeit.service.MessageService;
+import com.sprint.mission.discodeit.service.UserService;
+import com.sprint.mission.discodeit.service.basic.BasicChannelService;
+import com.sprint.mission.discodeit.service.basic.BasicMessageService;
+import com.sprint.mission.discodeit.service.basic.BasicUserService;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@SpringBootApplication
+public class DiscodeitApplication {
+//    static User setupUser(UserService userService) {
+//        User user = userService.create("woody", "woody@codeit.com", "woody1234", null);
+//        return user;
+//    }
+//
+//    static Channel setupChannel(ChannelService channelService) {
+//        Channel channel = channelService.create(ChannelType.PUBLIC, "공지", "공지 채널입니다.");
+//        return channel;
+//    }
+
+//    static void messageCreateTest(MessageService messageService, Channel channel, User author) {
+//        Message message = messageService.create("안녕하세요.", channel.getId(), author.getId());
+//        System.out.println("메시지 생성: " + message.getId());
+//    }
+
+    public static void main(String[] args) {
+        ConfigurableApplicationContext context = SpringApplication.run(DiscodeitApplication.class, args);
+        // 레포지토리 초기화
+        UserRepository userRepository = context.getBean(UserRepository.class);
+        ChannelRepository channelRepository = context.getBean(ChannelRepository.class);
+        MessageRepository messageRepository = context.getBean(MessageRepository.class);
+
+        // 서비스 초기화
+        UserService userService = context.getBean(UserService.class);
+        ChannelService channelService = context.getBean(ChannelService.class);
+        MessageService messageService = context.getBean(MessageService.class);
+
+        System.out.println(userRepository.getClass().getName());
+        System.out.println(channelRepository.getClass().getName());
+        System.out.println(messageRepository.getClass().getName());
+
+        System.out.println(userService.getClass().getName());
+        System.out.println(channelService.getClass().getName());
+        System.out.println(messageService.getClass().getName());
+
+        // 셋업
+//        User user = setupUser(userService);
+//        Channel channel = setupChannel(channelService);
+//         테스트
+//        messageCreateTest(messageService, channel, user);
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/ChannelCreateRequest.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/ChannelCreateRequest.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.dto;
+
+import com.sprint.mission.discodeit.entity.ChannelType;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ChannelCreateRequest(
+        String name,
+        String description,
+        ChannelType type,
+        List<UUID> members
+) {
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/ChannelFindResponse.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/ChannelFindResponse.java
@@ -1,0 +1,19 @@
+package com.sprint.mission.discodeit.dto;
+
+import com.sprint.mission.discodeit.entity.ChannelType;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Builder
+public record ChannelFindResponse(
+        UUID id,
+        String name,
+        String description,
+        ChannelType type,
+        Instant lastReadAt,
+        List<UUID> members
+) {
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/ChannelUpdateRequest.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/ChannelUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.sprint.mission.discodeit.dto;
+
+import com.sprint.mission.discodeit.entity.ChannelType;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ChannelUpdateRequest(
+        UUID channelId,
+        String name,
+        String description
+) {
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/MessageCreateRequest.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/MessageCreateRequest.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.discodeit.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record MessageCreateRequest(
+        String content,
+        UUID channelId,
+        UUID authorId,
+        List<UUID> attachmentIds
+) {
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/MessageUpdateRequest.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/MessageUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record MessageUpdateRequest(
+        UUID messageId,
+        String content
+) {
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/ReadStatusRequest.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/ReadStatusRequest.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReadStatusRequest(
+        UUID id,
+        UUID userId,
+        UUID channelId,
+        Instant lastReadAt
+) {}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/UserFindResponse.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/UserFindResponse.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.dto;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record UserFindResponse(
+        UUID id,
+        String username,
+        String email,
+        UUID profileId,
+        boolean isOnline
+) {
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/UserRequest.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/UserRequest.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.discodeit.dto;
+
+import java.util.UUID;
+
+public record UserRequest(
+        UUID id,
+        String username,
+        String email,
+        String password,
+        UUID profileId
+) {
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/UserStatusRequest.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/dto/UserStatusRequest.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserStatusRequest(
+        UUID id,
+        UUID userId,
+        Instant lastSeenAt
+) {
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
@@ -1,0 +1,33 @@
+package com.sprint.mission.discodeit.entity;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@ToString
+public class BinaryContent implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private UUID id;
+    private Instant createdAt;
+
+    private String fileName;
+    private String contentType; // jpg, ... 확장자
+    private Long size;
+    private byte[] bytes;
+
+    public BinaryContent(String fileName, String contentType, Long size, byte[] bytes) {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+        this.fileName = fileName;
+        this.contentType = contentType;
+        this.size = size;
+        this.bytes = bytes;
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/Channel.java
@@ -1,0 +1,44 @@
+package com.sprint.mission.discodeit.entity;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+public class Channel implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private ChannelType type;
+    private String name;
+    private String description;
+
+    public Channel(ChannelType type, String name, String description) {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+
+        this.type = type;
+        this.name = name;
+        this.description = description;
+    }
+
+    public void update(String newName, String newDescription) {
+        boolean anyValueUpdated = false;
+        if (newName != null && !newName.equals(this.name)) {
+            this.name = newName;
+            anyValueUpdated = true;
+        }
+        if (newDescription != null && !newDescription.equals(this.description)) {
+            this.description = newDescription;
+            anyValueUpdated = true;
+        }
+
+        if (anyValueUpdated) {
+            this.updatedAt = Instant.now();
+        }
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/ChannelType.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/ChannelType.java
@@ -1,0 +1,6 @@
+package com.sprint.mission.discodeit.entity;
+
+public enum ChannelType {
+    PUBLIC,
+    PRIVATE,
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/Message.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/Message.java
@@ -1,0 +1,71 @@
+package com.sprint.mission.discodeit.entity;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+public class Message implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private UUID id;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private String content;
+
+    private UUID channelId;
+    private UUID authorId;
+    private List<UUID> attachmentIds = new ArrayList<>();
+
+    public Message(String content, UUID channelId, UUID authorId, List<UUID> attachmentIds) {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+
+        this.content = content;
+        this.channelId = channelId;
+        this.authorId = authorId;
+        if (attachmentIds != null) {
+            this.attachmentIds = attachmentIds;
+        }
+    }
+
+    public void update(String newContent) {
+        boolean anyValueUpdated = false;
+        if (newContent != null && !newContent.equals(this.content)) {
+            this.content = newContent;
+            anyValueUpdated = true;
+        }
+
+        if (anyValueUpdated) {
+            this.updatedAt = Instant.now();
+        }
+    }
+
+    public void addAttachment (UUID attachmentId) {
+        if(!this.attachmentIds.contains(attachmentId)) {
+            this.attachmentIds.add(attachmentId);
+            this.updatedAt = Instant.now();
+        }
+    }
+
+    public void removeAttachment (UUID attachmentId) {
+        if(this.attachmentIds.contains(attachmentId)) {
+            this.attachmentIds.remove(attachmentId);
+            this.updatedAt = Instant.now();
+        }
+    }
+
+    public void setAttachmentIds (List<UUID> attachmentIds) {
+        if (!this.attachmentIds.equals(attachmentIds)) {
+            this.attachmentIds.clear();
+            this.attachmentIds.addAll(attachmentIds);
+            this.updatedAt = Instant.now();
+        }
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -1,0 +1,31 @@
+package com.sprint.mission.discodeit.entity;
+
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+public class ReadStatus {
+    private UUID id;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private UUID userId;
+    private UUID channelId;
+    private Instant lastReadAt;
+
+    public ReadStatus(UUID channelId, UUID userId) {
+        this.id = UUID.randomUUID();
+        this.userId = userId;
+        this.channelId = channelId;
+
+        this.createdAt = Instant.now();
+    }
+
+    public void update(Instant lastReadAt) {
+        this.lastReadAt = lastReadAt;
+        this.updatedAt = Instant.now();
+    }
+
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/User.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/User.java
@@ -1,0 +1,56 @@
+package com.sprint.mission.discodeit.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+public class User implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private UUID id;
+    private UUID profileId;
+    private Instant createdAt;
+    private Instant updatedAt;
+    //
+    private String username;
+    private String email;
+    private String password;
+
+    public User(String username, String email, String password, UUID profileId) {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+        //
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.profileId = profileId;
+    }
+
+    public void update(String newUsername, String newEmail, String newPassword ,UUID profileId) {
+        boolean anyValueUpdated = false;
+        if (newUsername != null && !newUsername.equals(this.username)) {
+            this.username = newUsername;
+            anyValueUpdated = true;
+        }
+        if (newEmail != null && !newEmail.equals(this.email)) {
+            this.email = newEmail;
+            anyValueUpdated = true;
+        }
+        if (newPassword != null && !newPassword.equals(this.password)) {
+            this.password = newPassword;
+            anyValueUpdated = true;
+        }
+        if(!profileId.equals(this.profileId)) {
+            this.profileId = profileId;
+            anyValueUpdated = true;
+        }
+
+        if (anyValueUpdated) {
+            this.updatedAt = Instant.now();
+        }
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
@@ -1,0 +1,35 @@
+package com.sprint.mission.discodeit.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+public class UserStatus {
+    private UUID id;
+    private Instant updatedAt;
+    private Instant createdAt;
+
+    private UUID userId;
+    private Instant lastSeenAt;
+
+    public UserStatus(UUID userId, Instant lastSeenAt) {
+        this.id = UUID.randomUUID();
+        this.userId = userId;
+        this.lastSeenAt = lastSeenAt;
+
+        this.createdAt = Instant.now();
+    }
+
+    public void update(Instant lastSeenAt) {
+        this.lastSeenAt = lastSeenAt;
+        this.updatedAt = Instant.now();
+    }
+
+    public boolean isOnLine() {
+        return Duration.between(lastSeenAt, Instant.now()).toMinutes() < 5;
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/BinaryContentRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/BinaryContentRepository.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface BinaryContentRepository {
+    BinaryContent save(BinaryContent binaryContent);
+    Optional<BinaryContent> findById(UUID id);
+    List<BinaryContent> findAllByIdIn(List<UUID> ids);
+    boolean existsById(UUID id);
+    void deleteById(UUID id);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/ChannelRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/ChannelRepository.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Channel;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ChannelRepository {
+    Channel save(Channel channel);
+    Optional<Channel> findById(UUID id);
+    List<Channel> findAll();
+    boolean existsById(UUID id);
+    void deleteById(UUID id);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.Message;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MessageRepository {
+    Message save(Message message);
+    Optional<Message> findById(UUID id);
+    List<Message> findAll();
+    boolean existsById(UUID id);
+    void deleteById(UUID id);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
@@ -1,0 +1,19 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository()
+public interface ReadStatusRepository {
+    ReadStatus save(ReadStatus readStatus);
+
+    Optional<ReadStatus> findById(UUID id);
+    List<ReadStatus> findAllByChannelId(UUID channelId);
+    List<ReadStatus> findAllByUserId(UUID userId);
+    boolean existsById(UUID id);
+    void deleteById(UUID id);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository {
+    User save(User user);
+    Optional<User> findById(UUID id);
+    List<User> findAll();
+    boolean existsById(UUID id);
+    void deleteById(UUID id);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/UserStatusRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/UserStatusRepository.java
@@ -1,0 +1,18 @@
+package com.sprint.mission.discodeit.repository;
+
+import com.sprint.mission.discodeit.entity.UserStatus;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserStatusRepository {
+    UserStatus save(UserStatus userStatus);
+    Optional<UserStatus> findById(UUID id);
+    List<UserStatus> findAll();
+    boolean existsById(UUID id);
+    boolean isOnline(UUID id);
+    void deleteById(UUID id);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/file/FileBinaryContentRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/file/FileBinaryContentRepository.java
@@ -1,0 +1,106 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.BinaryContentRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import org.springframework.stereotype.Repository;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository("fileBinaryContentRepository")
+public class FileBinaryContentRepository implements BinaryContentRepository {
+    private final Path DIRECTORY;
+    private final String EXTENSION = ".ser";
+
+    public FileBinaryContentRepository() {
+        this.DIRECTORY = Paths.get(System.getProperty("user.dir"), "file-data-map", "BinaryContent");
+        if (Files.notExists(DIRECTORY)) {
+            try {
+                Files.createDirectories(DIRECTORY);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private Path resolvePath(UUID id) {
+        return DIRECTORY.resolve(id + EXTENSION);
+    }
+
+    @Override
+    public BinaryContent save(BinaryContent binaryContent) {
+        Path path = resolvePath(binaryContent.getId());
+        try (
+                FileOutputStream fos = new FileOutputStream(path.toFile());
+                ObjectOutputStream oos = new ObjectOutputStream(fos)
+        ) {
+            oos.writeObject(binaryContent);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+        return binaryContent;
+    }
+
+    @Override
+    public Optional<BinaryContent> findById(UUID id) {
+        BinaryContent userNullable = null;
+        Path path = resolvePath(id);
+        if (Files.exists(path)) {
+            try (
+                    FileInputStream fis = new FileInputStream(path.toFile());
+                    ObjectInputStream ois = new ObjectInputStream(fis)
+            ) {
+                userNullable = (BinaryContent) ois.readObject();
+            } catch (IOException | ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.ofNullable(userNullable);
+    }
+
+    @Override
+    public List<BinaryContent> findAllByIdIn(List<UUID> ids) {
+        try {
+            return Files.list(DIRECTORY)
+                    .filter(path -> path.toString().endsWith(EXTENSION))
+                    .map(path -> {
+                        try (
+                                FileInputStream fis = new FileInputStream(path.toFile());
+                                ObjectInputStream ois = new ObjectInputStream(fis)
+                        ) {
+                            return (BinaryContent) ois.readObject();
+                        } catch (IOException | ClassNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .filter(content -> ids.contains(content.getId()))
+                    .toList();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        Path path = resolvePath(id);
+        return Files.exists(path);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        Path path = resolvePath(id);
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/file/FileChannelRepository.java
@@ -1,0 +1,112 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@ConditionalOnProperty(
+        prefix = "discodeit.repository",
+        name = "type",
+        havingValue = "file"
+)
+public class FileChannelRepository implements ChannelRepository {
+    private final Path DIRECTORY;
+    private final String EXTENSION = ".ser";
+
+    @Value("${discodeit.repository.file-directory}")
+    private String fileDirectory;
+
+    public FileChannelRepository() {
+        this.DIRECTORY = Paths.get(fileDirectory, "file-data-map", Channel.class.getSimpleName());
+        if (Files.notExists(DIRECTORY)) {
+            try {
+                Files.createDirectories(DIRECTORY);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private Path resolvePath(UUID id) {
+        return DIRECTORY.resolve(id + EXTENSION);
+    }
+
+    @Override
+    public Channel save(Channel channel) {
+        Path path = resolvePath(channel.getId());
+        try (
+                FileOutputStream fos = new FileOutputStream(path.toFile());
+                ObjectOutputStream oos = new ObjectOutputStream(fos)
+        ) {
+            oos.writeObject(channel);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return channel;
+    }
+
+    @Override
+    public Optional<Channel> findById(UUID id) {
+        Channel channelNullable = null;
+        Path path = resolvePath(id);
+        if (Files.exists(path)) {
+            try (
+                    FileInputStream fis = new FileInputStream(path.toFile());
+                    ObjectInputStream ois = new ObjectInputStream(fis)
+            ) {
+                channelNullable = (Channel) ois.readObject();
+            } catch (IOException | ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.ofNullable(channelNullable);
+    }
+
+    @Override
+    public List<Channel> findAll() {
+        try {
+            return Files.list(DIRECTORY)
+                    .filter(path -> path.toString().endsWith(EXTENSION))
+                    .map(path -> {
+                        try (
+                                FileInputStream fis = new FileInputStream(path.toFile());
+                                ObjectInputStream ois = new ObjectInputStream(fis)
+                        ) {
+                            return (Channel) ois.readObject();
+                        } catch (IOException | ClassNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .toList();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        Path path = resolvePath(id);
+        return Files.exists(path);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        Path path = resolvePath(id);
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
@@ -1,0 +1,112 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository()
+@ConditionalOnProperty(
+        prefix = "discodeit.repository",
+        name = "type",
+        havingValue = "file"
+)
+public class FileMessageRepository implements MessageRepository {
+    private final Path DIRECTORY;
+    private final String EXTENSION = ".ser";
+
+    @Value("${discodeit.repository.file-directory}")
+    private String fileDirectory;
+
+    public FileMessageRepository() {
+        this.DIRECTORY = Paths.get(fileDirectory, "file-data-map", Message.class.getSimpleName());
+        if (Files.notExists(DIRECTORY)) {
+            try {
+                Files.createDirectories(DIRECTORY);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private Path resolvePath(UUID id) {
+        return DIRECTORY.resolve(id + EXTENSION);
+    }
+
+    @Override
+    public Message save(Message message) {
+        Path path = resolvePath(message.getId());
+        try (
+                FileOutputStream fos = new FileOutputStream(path.toFile());
+                ObjectOutputStream oos = new ObjectOutputStream(fos)
+        ) {
+            oos.writeObject(message);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return message;
+    }
+
+    @Override
+    public Optional<Message> findById(UUID id) {
+        Message messageNullable = null;
+        Path path = resolvePath(id);
+        if (Files.exists(path)) {
+            try (
+                    FileInputStream fis = new FileInputStream(path.toFile());
+                    ObjectInputStream ois = new ObjectInputStream(fis)
+            ) {
+                messageNullable = (Message) ois.readObject();
+            } catch (IOException | ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.ofNullable(messageNullable);
+    }
+
+    @Override
+    public List<Message> findAll() {
+        try {
+            return Files.list(DIRECTORY)
+                    .filter(path -> path.toString().endsWith(EXTENSION))
+                    .map(path -> {
+                        try (
+                                FileInputStream fis = new FileInputStream(path.toFile());
+                                ObjectInputStream ois = new ObjectInputStream(fis)
+                        ) {
+                            return (Message) ois.readObject();
+                        } catch (IOException | ClassNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .toList();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        Path path = resolvePath(id);
+        return Files.exists(path);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        Path path = resolvePath(id);
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
@@ -1,0 +1,112 @@
+package com.sprint.mission.discodeit.repository.file;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository()
+@ConditionalOnProperty(
+        prefix = "discodeit.repository",
+        name = "type",
+        havingValue = "file"
+)
+public class FileUserRepository implements UserRepository {
+    private final Path DIRECTORY;
+    private final String EXTENSION = ".ser";
+
+    @Value("${discodeit.repository.file-directory}")
+    private String fileDirectory;
+
+    public FileUserRepository() {
+        this.DIRECTORY = Paths.get(fileDirectory, "file-data-map", User.class.getSimpleName());
+        if (Files.notExists(DIRECTORY)) {
+            try {
+                Files.createDirectories(DIRECTORY);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private Path resolvePath(UUID id) {
+        return DIRECTORY.resolve(id + EXTENSION);
+    }
+
+    @Override
+    public User save(User user) {
+        Path path = resolvePath(user.getId());
+        try (
+                FileOutputStream fos = new FileOutputStream(path.toFile());
+                ObjectOutputStream oos = new ObjectOutputStream(fos)
+        ) {
+            oos.writeObject(user);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return user;
+    }
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        User userNullable = null;
+        Path path = resolvePath(id);
+        if (Files.exists(path)) {
+            try (
+                    FileInputStream fis = new FileInputStream(path.toFile());
+                    ObjectInputStream ois = new ObjectInputStream(fis)
+            ) {
+                userNullable = (User) ois.readObject();
+            } catch (IOException | ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.ofNullable(userNullable);
+    }
+
+    @Override
+    public List<User> findAll() {
+        try {
+            return Files.list(DIRECTORY)
+                    .filter(path -> path.toString().endsWith(EXTENSION))
+                    .map(path -> {
+                        try (
+                                FileInputStream fis = new FileInputStream(path.toFile());
+                                ObjectInputStream ois = new ObjectInputStream(fis)
+                        ) {
+                            return (User) ois.readObject();
+                        } catch (IOException | ClassNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .toList();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        Path path = resolvePath(id);
+        return Files.exists(path);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        Path path = resolvePath(id);
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFChannelRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFChannelRepository.java
@@ -1,0 +1,49 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service()
+@ConditionalOnProperty(
+        prefix = "discodeit.repository",
+        name = "type",
+        havingValue = "jcf",
+        matchIfMissing = true
+)
+public class JCFChannelRepository implements ChannelRepository {
+    private final Map<UUID, Channel> data;
+
+    public JCFChannelRepository() {
+        this.data = new HashMap<>();
+    }
+
+    @Override
+    public Channel save(Channel channel) {
+        this.data.put(channel.getId(), channel);
+        return channel;
+    }
+
+    @Override
+    public Optional<Channel> findById(UUID id) {
+        return Optional.ofNullable(this.data.get(id));
+    }
+
+    @Override
+    public List<Channel> findAll() {
+        return this.data.values().stream().toList();
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return this.data.containsKey(id);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        this.data.remove(id);
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFMessageRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFMessageRepository.java
@@ -1,0 +1,49 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository()
+@ConditionalOnProperty(
+        prefix = "discodeit.repository",
+        name = "type",
+        havingValue = "jcf",
+        matchIfMissing = true
+)
+public class JCFMessageRepository implements MessageRepository {
+    private final Map<UUID, Message> data;
+
+    public JCFMessageRepository() {
+        this.data = new HashMap<>();
+    }
+
+    @Override
+    public Message save(Message message) {
+        this.data.put(message.getId(), message);
+        return message;
+    }
+
+    @Override
+    public Optional<Message> findById(UUID id) {
+        return Optional.ofNullable(this.data.get(id));
+    }
+
+    @Override
+    public List<Message> findAll() {
+        return this.data.values().stream().toList();
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return this.data.containsKey(id);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        this.data.remove(id);
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFUserRepository.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFUserRepository.java
@@ -1,0 +1,49 @@
+package com.sprint.mission.discodeit.repository.jcf;
+
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository()
+@ConditionalOnProperty(
+        prefix = "discodeit.repository",
+        name = "type",
+        havingValue = "jcf",
+        matchIfMissing = true
+)
+public class JCFUserRepository implements UserRepository {
+    private final Map<UUID, User> data;
+
+    public JCFUserRepository() {
+        this.data = new HashMap<>();
+    }
+
+    @Override
+    public User save(User user) {
+        this.data.put(user.getId(), user);
+        return user;
+    }
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        return Optional.ofNullable(this.data.get(id));
+    }
+
+    @Override
+    public List<User> findAll() {
+        return this.data.values().stream().toList();
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return this.data.containsKey(id);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        this.data.remove(id);
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/AuthService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/AuthService.java
@@ -1,0 +1,23 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.UserRequest;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service("authService")
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserRepository userRepository;
+
+    public User login(UserRequest request) {
+        List<User> users = userRepository.findAll();
+
+        return users.stream().filter(u -> u.getUsername().equals(request.username()) && u.getPassword().equals(request.password()))
+                .findAny().orElseThrow(() -> new NoSuchElementException("일치하는 사용자가 존재하지 않습니다."));
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -1,0 +1,21 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.ChannelCreateRequest;
+import com.sprint.mission.discodeit.dto.ChannelFindResponse;
+import com.sprint.mission.discodeit.dto.ChannelUpdateRequest;
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ChannelType;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public interface ChannelService {
+    Channel createPublicChannel(ChannelCreateRequest request);
+    Channel createPrivateChannel(ChannelCreateRequest request);
+    ChannelFindResponse find(UUID channelId);
+    List<ChannelFindResponse> findAll(UUID userId);
+    Instant getLastReadAt(UUID channelId);
+    Channel update(ChannelUpdateRequest request);
+    void delete(UUID channelId);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.MessageCreateRequest;
+import com.sprint.mission.discodeit.dto.MessageUpdateRequest;
+import com.sprint.mission.discodeit.entity.Message;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MessageService {
+    Message create(MessageCreateRequest request);
+    Message find(UUID messageId);
+    List<Message> findAllByChannelId(UUID channelId);
+    Message update(MessageUpdateRequest request);
+    void delete(UUID messageId);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/ReadStatusService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/ReadStatusService.java
@@ -1,0 +1,66 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.ReadStatusRequest;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service("readStatusService")
+public class ReadStatusService {
+
+    private final ReadStatusRepository readStatusRepository;
+    private final UserRepository userRepository;
+    private final ChannelRepository channelRepository;
+
+    @Autowired
+    public ReadStatusService(ReadStatusRepository readStatusRepository,
+                             @Qualifier("fileUserRepository") UserRepository userRepository,
+                             @Qualifier("fileChannelRepository") ChannelRepository channelRepository) {
+        this.readStatusRepository = readStatusRepository;
+        this.userRepository = userRepository;
+        this.channelRepository = channelRepository;
+    }
+
+    public ReadStatus create(ReadStatusRequest request) {
+        if (!userRepository.existsById(request.userId())) {
+            throw new IllegalArgumentException("{"+ request.userId() + "} 사용자가 존재하지 않습니다.");
+        }
+        if (!channelRepository.existsById(request.channelId())) {
+            throw new IllegalArgumentException("{"+ request.channelId() + "} 채널이 존재하지 않습니다.");
+        }
+        List<ReadStatus>  userReadStatuses = readStatusRepository.findAllByUserId(request.userId());
+        userReadStatuses.forEach(v -> {
+            if(v.getChannelId().equals(request.channelId())) {
+                throw new IllegalArgumentException(request.userId() + "- 유저와, " + request.channelId() + "- 채널과 관련된 객체가 이미 존재합니다.");
+            }
+        });
+
+        return readStatusRepository.save(new ReadStatus(request.channelId(), request.userId()));
+    }
+
+    public ReadStatus find(UUID id) {
+        return readStatusRepository.findById(id).orElseThrow(NoSuchElementException::new);
+    }
+
+    public List<ReadStatus> findAllByUserId(UUID userId) {
+        return readStatusRepository.findAllByUserId(userId);
+    }
+
+    public ReadStatus update(ReadStatusRequest request) {
+        ReadStatus readStatus = readStatusRepository.findById(request.id()).orElseThrow(NoSuchElementException::new);
+        readStatus.update(request.lastReadAt());
+        return readStatusRepository.save(readStatus);
+    }
+
+    public void delete(UUID id) {
+        readStatusRepository.deleteById(id);
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/UserService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/UserService.java
@@ -1,0 +1,16 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.UserRequest;
+import com.sprint.mission.discodeit.dto.UserFindResponse;
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserService {
+    User create(UserRequest request);
+    UserFindResponse find(UUID userId);
+    List<UserFindResponse> findAll();
+    User update(UserRequest request);
+    void delete(UUID userId);
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/UserStatusService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/UserStatusService.java
@@ -1,0 +1,71 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.UserStatusRequest;
+import com.sprint.mission.discodeit.entity.UserStatus;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.UserStatusRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service("userStatusService")
+public class UserStatusService {
+    private final UserStatusRepository userStatusRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserStatusService(UserStatusRepository userStatusRepository, @Qualifier("fileUserRepository") UserRepository userRepository) {
+        this.userStatusRepository = userStatusRepository;
+        this.userRepository = userRepository;
+    }
+
+    public UserStatus create(UserStatusRequest request) {
+        if (!userRepository.existsById(request.userId())) {
+            throw new IllegalArgumentException(String.format("{%s} 유저가 존재하지 않습니다.", request.userId()));
+        }
+        List<UserStatus> userStatuses = userStatusRepository.findAll();
+        userStatuses.forEach(v -> {
+            if(v.getUserId().equals(request.userId())) {
+                throw new IllegalArgumentException(request.userId() + "와 관련된 객체가 이미 존재합니다.");
+            }
+        });
+
+        return userStatusRepository.save(new UserStatus(request.userId(), request.lastSeenAt()));
+    }
+
+    public UserStatus find(UUID id) {
+        return userStatusRepository.findById(id).orElseThrow(NoSuchElementException::new);
+    }
+
+    public List<UserStatus> findAll() {
+        return userStatusRepository.findAll();
+    }
+
+    public UserStatus update(UserStatusRequest request) {
+        UserStatus userStatus = userStatusRepository.findById(request.id()).orElseThrow(NoSuchElementException::new);
+        userStatus.update(request.lastSeenAt());
+        return userStatusRepository.save(userStatus);
+    }
+
+    public UserStatus updateById(UUID userId, Instant lastSeenAt) {
+        List<UserStatus> userStatuses = userStatusRepository.findAll();
+        for (UserStatus v : userStatuses) {
+            if (v.getUserId().equals(userId)) {
+                v.update(lastSeenAt);
+                return  userStatusRepository.save(v);
+            }
+        }
+        throw new IllegalArgumentException("해당 user가 존재하지 않습니다.");
+    }
+
+    public void delete(UUID id) {
+        userStatusRepository.deleteById(id);
+    }
+
+
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -1,0 +1,163 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.ChannelCreateRequest;
+import com.sprint.mission.discodeit.dto.ChannelFindResponse;
+import com.sprint.mission.discodeit.dto.ChannelUpdateRequest;
+import com.sprint.mission.discodeit.entity.Channel;
+import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
+import com.sprint.mission.discodeit.service.ChannelService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service("basicChannelService")
+
+public class BasicChannelService implements ChannelService {
+    private final ChannelRepository channelRepository;
+    private final ReadStatusRepository readStatusRepository;
+    private final MessageRepository messageRepository;
+
+    @Autowired
+    public BasicChannelService(ChannelRepository channelRepository,
+                               MessageRepository messageRepository,
+                               ReadStatusRepository readStatusRepository) {
+        this.channelRepository = channelRepository;
+        this.messageRepository = messageRepository;
+        this.readStatusRepository = readStatusRepository;
+    }
+
+    @Override
+    public Channel createPublicChannel(ChannelCreateRequest request) {
+        if (request.type().equals(ChannelType.PUBLIC)) {
+            Channel channel = new Channel(ChannelType.PUBLIC, request.name(), request.description());
+            return channelRepository.save(channel);
+        }
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public Channel createPrivateChannel(ChannelCreateRequest request) {
+        if (request.type().equals(ChannelType.PRIVATE)) {
+            Channel channel = new Channel(ChannelType.PRIVATE, null, null);
+            List<UUID> members = request.members();
+            for(UUID member : members){
+                ReadStatus readStatus = new ReadStatus(channel.getId(), member);
+                readStatusRepository.save(readStatus);
+            }
+            return channelRepository.save(channel);
+        }
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public ChannelFindResponse find(UUID channelId) {
+        Channel channel = channelRepository.findById(channelId)
+                        .orElseThrow(() -> new NoSuchElementException("Channel with id " + channelId + " not found"));
+
+        Instant lastReadAt = getLastReadAt(channelId);
+        if (channel.getType().equals(ChannelType.PUBLIC)) {
+            return ChannelFindResponse.builder().id(channelId).name(channel.getName())
+                    .description(channel.getDescription()).type(ChannelType.PUBLIC)
+                    .lastReadAt(lastReadAt)
+                    .build();
+        } else {
+            List<UUID> members = new ArrayList<>();
+            readStatusRepository.findAllByChannelId(channelId).forEach(v -> members.add(v.getUserId()));
+            return ChannelFindResponse.builder().id(channelId).name(null).description(null)
+                    .type(ChannelType.PRIVATE).lastReadAt(lastReadAt)
+                    .members(members)
+                    .build();
+        }
+    }
+
+    @Override
+    public List<ChannelFindResponse> findAll(UUID userId) {
+        List<Channel> allChannels = channelRepository.findAll();
+        List<ChannelFindResponse> channelList = new ArrayList<>();
+        List<UUID> channelsHasUser = new ArrayList<>();
+
+        readStatusRepository.findAllByUserId(userId).forEach(v -> channelsHasUser.add(v.getChannelId()));
+        for (Channel channel : allChannels) {
+            if (channel.getType().equals(ChannelType.PRIVATE) && !channelsHasUser.contains(channel.getId())) {
+                allChannels.remove(channel);
+            }
+        }
+
+        for (Channel channel : allChannels) {
+            Instant lastReadAt = getLastReadAt(channel.getId());
+            if (channel.getType().equals(ChannelType.PUBLIC)) {
+                channelList.add(ChannelFindResponse.builder().id(channel.getId())
+                        .name(channel.getName()).description(channel.getDescription())
+                        .type(ChannelType.PUBLIC).lastReadAt(lastReadAt)
+                        .build());
+            } else {
+                List<UUID> members = new ArrayList<>();
+                readStatusRepository.findAllByChannelId(channel.getId()).forEach(v -> members.add(v.getUserId()));
+                channelList.add(ChannelFindResponse.builder().id(channel.getId()).name(null).description(null)
+                        .type(ChannelType.PRIVATE).lastReadAt(lastReadAt)
+                        .members(members)
+                        .build());
+            }
+        }
+        return channelList;
+    }
+
+    @Override
+    public Channel update(ChannelUpdateRequest request) {
+        Channel channel = channelRepository.findById(request.channelId())
+                .orElseThrow(() -> new NoSuchElementException("Channel with id " + request.channelId() + " not found"));
+        if (channel.getType().equals(ChannelType.PRIVATE)) {
+            throw new IllegalArgumentException("PRIVATE 채널은 수정할 수 없습니다.");
+        }
+        channel.update(request.name(), request.description());
+        return channelRepository.save(channel);
+    }
+
+    @Override
+    public Instant getLastReadAt(UUID channelId) {
+        List<Message> messages = messageRepository.findAll();
+
+        Instant lastReadAt = null;
+        for(Message message : messages){
+            if(lastReadAt == null) {
+                lastReadAt = message.getCreatedAt();
+            } else {
+                if (lastReadAt.compareTo(message.getCreatedAt()) < 0) {
+                    lastReadAt = message.getCreatedAt();
+                }
+            }
+        }
+        return lastReadAt;
+    }
+
+    @Override
+    public void delete(UUID channelId) {
+        if (!channelRepository.existsById(channelId)) {
+            throw new NoSuchElementException("Channel with id " + channelId + " not found");
+        }
+        List<Message> messages = messageRepository.findAll();
+        for (Message message : messages) {
+            if (channelId.equals(message.getChannelId())) {
+                messageRepository.deleteById(message.getId());
+            }
+        }
+        List<ReadStatus> readStatuses = readStatusRepository.findAllByChannelId(channelId);
+        for (ReadStatus readStatus : readStatuses) {
+            if (channelId.equals(readStatus.getChannelId())) {
+                readStatusRepository.deleteById(readStatus.getId());
+            }
+        }
+        channelRepository.deleteById(channelId);
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -1,0 +1,81 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.MessageCreateRequest;
+import com.sprint.mission.discodeit.dto.MessageUpdateRequest;
+import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.BinaryContentRepository;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service("basicMessageService")
+public class BasicMessageService implements MessageService {
+    private final MessageRepository messageRepository;
+    private final ChannelRepository channelRepository;
+    private final UserRepository userRepository;
+    private final BinaryContentRepository  binaryContentRepository;
+
+    @Autowired
+    public BasicMessageService (MessageRepository messageRepository,
+                                ChannelRepository channelRepository,
+                                UserRepository userRepository,
+                                BinaryContentRepository binaryContentRepository) {
+        this.messageRepository = messageRepository;
+        this.channelRepository = channelRepository;
+        this.userRepository = userRepository;
+        this.binaryContentRepository = binaryContentRepository;
+    }
+
+    @Override
+    public Message create(MessageCreateRequest request) {
+        if (!channelRepository.existsById(request.channelId())) {
+            throw new NoSuchElementException("Channel not found with id " + request.channelId());
+        }
+        if (!userRepository.existsById(request.authorId())) {
+            throw new NoSuchElementException("Author not found with id " + request.authorId());
+        }
+
+        Message message = new Message(request.content(), request.channelId(), request.authorId(), request.attachmentIds());
+        return messageRepository.save(message);
+    }
+
+    @Override
+    public Message find(UUID messageId) {
+        return messageRepository.findById(messageId)
+                .orElseThrow(() -> new NoSuchElementException("Message with id " + messageId + " not found"));
+    }
+
+    @Override
+    public List<Message> findAllByChannelId(UUID channelId) {
+        List<Message> messages = new ArrayList<>();
+        messageRepository.findAll().forEach(v -> { if(v.getChannelId().equals(channelId)) {
+            messages.add(v);
+        }
+        });
+        return messages;
+    }
+
+    @Override
+    public Message update(MessageUpdateRequest request) {
+        Message message = messageRepository.findById(request.messageId())
+                .orElseThrow(() -> new NoSuchElementException("Message with id " + request.messageId() + " not found"));
+        message.update(request.content());
+        return messageRepository.save(message);
+    }
+
+    @Override
+    public void delete(UUID messageId) {
+        if (!messageRepository.existsById(messageId)) {
+            throw new NoSuchElementException("Message with id " + messageId + " not found");
+        }
+        // BinaryContent 삭제
+        messageRepository.deleteById(messageId);
+    }
+}

--- a/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/5-sprint-mission3/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -1,0 +1,98 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.UserRequest;
+import com.sprint.mission.discodeit.dto.UserFindResponse;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.entity.UserStatus;
+import com.sprint.mission.discodeit.repository.BinaryContentRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.UserStatusRepository;
+import com.sprint.mission.discodeit.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service("basicUserService")
+public class BasicUserService implements UserService {
+    private final UserRepository userRepository;
+    private final BinaryContentRepository binaryContentRepository;
+    private final UserStatusRepository userStatusRepository;
+
+    @Autowired
+    public BasicUserService(UserRepository userRepository,
+                            BinaryContentRepository binaryContentRepository,
+                            UserStatusRepository userStatusRepository) {
+        this.userRepository = userRepository;
+        this.binaryContentRepository = binaryContentRepository;
+        this.userStatusRepository = userStatusRepository;
+    }
+
+    @Override
+    public User create(UserRequest request) {
+        List<UserFindResponse> users = findAll();
+        users.forEach(u -> {
+            if(u.username().equals(request.username())) {
+                throw new IllegalArgumentException("[Error]: 이름이 중복됩니다.");
+            }
+            if(u.email().equals(request.email())) {
+                throw new IllegalArgumentException("[Error]: 이메일이 중복됩니다.");
+            }
+        });
+
+        User user = new User(request.username(), request.email(), request.password(), request.profileId());
+        userStatusRepository.save(new UserStatus(user.getId(), user.getCreatedAt()));
+
+        return userRepository.save(user);
+    }
+
+    @Override
+    public UserFindResponse find(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("User with id " + userId + " not found"));
+
+        return UserFindResponse.builder().id(user.getId()).username(user.getUsername())
+                .email(user.getEmail()).profileId(user.getProfileId())
+                .isOnline(userStatusRepository.isOnline(user.getId())).build();
+    }
+
+    @Override
+    public List<UserFindResponse> findAll() {
+        return userRepository.findAll().stream()
+                .map(user -> UserFindResponse.builder()
+                .id(user.getId()).username(user.getUsername())
+                .email(user.getEmail()).profileId(user.getProfileId())
+                .isOnline(userStatusRepository.isOnline(user.getId())).build())
+                .toList();
+    }
+
+    @Override
+    public User update(UserRequest request) {
+        User user = userRepository.findById(request.id())
+                .orElseThrow(() -> new NoSuchElementException("User with id " + request.id() + " not found"));
+        user.update(request.username(), request.email(), request.password(), request.profileId());
+        return userRepository.save(user);
+    }
+
+    @Override
+    public void delete(UUID userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new NoSuchElementException("User with id " + userId + " not found");
+        }
+
+        binaryContentRepository.deleteById(userRepository.findById(userId).get().getProfileId());
+        List<UserStatus> userStatuses =  userStatusRepository.findAll();
+        userStatuses.forEach(v -> {
+            if(v.getUserId().equals(userId)) {
+                userStatusRepository.deleteById(v.getId());
+            }
+        });
+
+        userRepository.deleteById(userId);
+    }
+}

--- a/5-sprint-mission3/src/main/resources/application.yaml
+++ b/5-sprint-mission3/src/main/resources/application.yaml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: discodeit
+
+discodeit:
+  repository:
+    type: jcf   # jcf | file
+    file-directory: .discodeit


### PR DESCRIPTION
## 요구사항

### 기본 요구사항

- [x] File*Repository 구현체를 Repository 인터페이스의 Bean으로 등록하세요.
- [x] Basic*Service 구현체를 Service 인터페이스의 Bean으로 등록하세요.
- [x] JavaApplication에서 테스트했던 코드를 DiscodeitApplication에서 테스트해보세요.
- [x]  JavaApplication 의 main 메소드를 제외한 모든 메소드를 DiscodeitApplication클래스로 복사하세요.

- [x]  JavaApplication의 main 메소드에서 Service를 초기화하는 코드를 Spring Context를 활용하여 대체하세요.
- [x]  JavaApplication의 main 메소드의 셋업, 테스트 부분의 코드를 DiscodeitApplication클래스로 복사하세요.

#### Spring 핵심 개념 이해하기
- [ ] JavaApplication과 DiscodeitApplication에서 Service를 초기화하는 방식의 차이에 대해 다음의 키워드를 중심으로 정리해보세요.
(IoC Container, Dependency Injection, Bean)- 이 부분을 작성하기 전 첫 pr이 일요일 23시 59분 즈음 제출되었으므로, 간단하게 작성해보겠습니다. 
`기존 자바에서는 Service변수를 선언하고 new 생성자를 통해서 해당 객체를 생성하여 변수에 삽입하여 연결하는 식으로 초기화 했습니다.
Spring에서는 프로젝트가 실행되었을 때, @ComponentScan 어노테이션을 통해 각 서비스에 입력된 @Service 어노테이션을 읽어와 자동으로 Bean을 생성합니다. 그리고 개발자가 직접 new 생성자를 통해 초기화할 필요없이 IoC 컨테이너가 자동으로 의존성을 주입해줍니다. 예를 들어 @Autowired 어노테이션이나 @RequiredArgsConstructor 어노테이션을 통해 의존성을 주입합니다.`


#### Lombok 적용
- [x] 도메인 모델의 getter 메소드를 @Getter로 대체해보세요.
- [x] Basic*Service의 생성자를 @RequiredArgsConstructor로 대체해보세요.

<br><hr>

### 추가 기능 요구사항
#### 시간 타입 변경하기
- [x] 시간을 다루는 필드의 타입은 Instant로 통일합니다

#### 새로운 도메인 추가하기
도메인 모델 간 참조 관계를 참고하세요.
- [x]  공통: 앞서 정의한 도메인 모델과 동일하게 공통 필드(id, createdAt, updatedAt)를 포함합니다.

- [x]  ReadStatus
사용자가 채널 별 마지막으로 메시지를 읽은 시간을 표현하는 도메인 모델입니다. 사용자별 각 채널에 읽지 않은 메시지를 확인하기 위해 활용합니다.

- [x] UserStatus
사용자 별 마지막으로 확인된 접속 시간을 표현하는 도메인 모델입니다. 사용자의 온라인 상태를 확인하기 위해 활용합니다.
- [x] 마지막 접속 시간을 기준으로 현재 로그인한 유저로 판단할 수 있는 메소드를 정의하세요.
마지막 접속 시간이 현재 시간으로부터 5분 이내이면 현재 접속 중인 유저로 간주합니다.

- [x] BinaryContent
이미지, 파일 등 바이너리 데이터를 표현하는 도메인 모델입니다. 사용자의 프로필 이미지, 메시지에 첨부된 파일을 저장하기 위해 활용합니다.
- [x] 수정 불가능한 도메인 모델로 간주합니다. 따라서 updatedAt 필드는 정의하지 않습니다.
- [x] User, Message 도메인 모델과의 의존 관계 방향성을 잘 고려하여 id 참조 필드를 추가하세요.
- [x]  각 도메인 모델 별 레포지토리 인터페이스를 선언하세요.

<br>

#### UserService 고도화
##### 고도화
create
- [x] 선택적으로 프로필 이미지를 같이 등록할 수 있습니다.
- [x] DTO를 활용해 파라미터를 그룹화합니다.
유저를 등록하기 위해 필요한 파라미터, 프로필 이미지를 등록하기 위해 필요한 파라미터 등
- [x] username과 email은 다른 유저와 같으면 안됩니다.
- [x] UserStatus를 같이 생성합니다.

find, findAll
DTO를 활용하여:
- [x] 사용자의 온라인 상태 정보를 같이 포함하세요.
- [x] 패스워드 정보는 제외하세요.
update
- [x] 선택적으로 프로필 이미지를 대체할 수 있습니다.
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터

delete
- [x] 관련된 도메인도 같이 삭제합니다.
BinaryContent(프로필), UserStatus

<br>

#### AuthService 구현
login
- [x] username, password과 일치하는 유저가 있는지 확인합니다.
- [x] 일치하는 유저가 있는 경우: 유저 정보 반환
- [x] 일치하는 유저가 없는 경우: 예외 발생
- [x] DTO를 활용해 파라미터를 그룹화합니다.

<br>

#### ChannelService 고도화
##### 고도화
create
PRIVATE 채널과 PUBLIC 채널을 생성하는 메소드를 분리합니다.
- [x] 분리된 각각의 메소드를 DTO를 활용해 파라미터를 그룹화합니다.
PRIVATE 채널을 생성할 때:
- [x] 채널에 참여하는 User의 정보를 받아 User 별 ReadStatus 정보를 생성합니다.
- [x] name과 description 속성은 생략합니다.
PUBLIC 채널을 생성할 때에는 기존 로직을 유지합니다.
find
DTO를 활용하여:
- [x] 해당 채널의 가장 최근 메시지의 시간 정보를 포함합니다.
- [x] PRIVATE 채널인 경우 참여한 User의 id 정보를 포함합니다.
findAll
DTO를 활용하여:
- [x] 해당 채널의 가장 최근 메시지의 시간 정보를 포함합니다.
- [x] PRIVATE 채널인 경우 참여한 User의 id 정보를 포함합니다.
- [x] 특정 User가 볼 수 있는 Channel 목록을 조회하도록 조회 조건을 추가하고, 메소드 명을 변경합니다. findAllByUserId
- [x] PUBLIC 채널 목록은 전체 조회합니다.
- [x] PRIVATE 채널은 조회한 User가 참여한 채널만 조회합니다.
update
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
- [x] PRIVATE 채널은 수정할 수 없습니다.
delete
- [ ] 관련된 도메인도 같이 삭제합니다.
Message, ReadStatus

<br>

#### MessageService 고도화
##### 고도화
create
- [x] 선택적으로 여러 개의 첨부파일을 같이 등록할 수 있습니다.
- [x] DTO를 활용해 파라미터를 그룹화합니다.
findAll
- [x] 특정 Channel의 Message 목록을 조회하도록 조회 조건을 추가하고, 메소드 명을 변경합니다. findallByChannelId
update
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
delete
- [ ] 관련된 도메인도 같이 삭제합니다.
첨부파일(BinaryContent)

<br>

#### ReadStatusService 구현
create
- [x] DTO를 활용해 파라미터를 그룹화합니다.
- [x] 관련된 Channel이나 User가 존재하지 않으면 예외를 발생시킵니다.
- [x] 같은 Channel과 User와 관련된 객체가 이미 존재하면 예외를 발생시킵니다.
find
- [x] id로 조회합니다.
findAllByUserId
- [x] userId를 조건으로 조회합니다.
update
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
delete
- [x] id로 삭제합니다

<br>

#### UserStatusService 고도화
create
- [x] DTO를 활용해 파라미터를 그룹화합니다.
- [x] 관련된 User가 존재하지 않으면 예외를 발생시킵니다.
- [x] 같은 User와 관련된 객체가 이미 존재하면 예외를 발생시킵니다.
find
- [x] id로 조회합니다.
findAll
- [x] 모든 객체를 조회합니다.
update
- [x] DTO를 활용해 파라미터를 그룹화합니다.
수정 대상 객체의 id 파라미터, 수정할 값 파라미터
updateByUserId
- [x] userId 로 특정 User의 객체를 업데이트합니다.
delete
- [x] id로 삭제합니다.

<br>

#### BinaryContentService 구현
create
- [ ] DTO를 활용해 파라미터를 그룹화합니다.
find
- [ ] id로 조회합니다.
findAllByIdIn
- [ ] id 목록으로 조회합니다.
delete
- [ ] id로 삭제합니다.

#### 새로운 도메인 Repository 구현체 구현
- [ ]  지금까지 인터페이스로 설계한 각각의 Repository를 JCF, File로 각각 구현하세요.

<br><hr>

## 심화 요구사항
### Bean 다루기
- [x]  Repository 구현체 중에 어떤 구현체를 Bean으로 등록할지 Java 코드의 변경 없이 application.yaml 설정 값을 통해 제어해보세요.
- [x] discodeit.repository.type 설정값에 따라 Repository 구현체가 정해집니다.
- [x] 값이 jcf 이거나 없으면 JCF*Repository 구현체가 Bean으로 등록되어야 합니다.
- [x] 값이 file 이면 File*Repository 구현체가 Bean으로 등록되어야 합니다.
- [x]  File*Repository 구현체의 파일을 저장할 디렉토리 경로를 application.yaml 설정 값을 통해 제어해보세요.

<br><hr>

## 멘토에게

-  스프린트3에서 제공하는 기본 코드 zip을 기반으로 작성하였습니다.
-  원래는 sprint2의 코드를 밀어버리고 제공 받은 코드를 작성해서 브랜치에 새롭게 올리려고 했는데, 기존에 작성했던 코드는 그대로 있고, 대신 새로운 폴더가 생겨서 [5-sprint-mission3](https://github.com/rlawnsry/5-sprint-mission/tree/%EA%B9%80%EC%A4%80%EA%B5%90-sprint3/5-sprint-mission3)에 commit이 올라갔습니다. 

<br>

##### 하지 못한 부분
- 기존 Service 고도화 부분의 delete 메서드에서 BinaryContent 도메인을 삭제하지 못했습니다.
- BinaryContentService를 작성하지 못했습니다.
- sprint3에서 새로 작성한 도메인들의 인터페이스 구현체를 작성하지 못했습니다.

<br>

##### 질문할 점
-  최대한 요구 사항대로만 작성하다가 도메인의 Service의 create() 메서드에서 예를 들어, UserStatus나 ReadStatus에 새로 추가하고자 하는 유저나 채널이 이미 존재하는지 확인하는 과정에서 전체 객체를 다 읽어 온 다음 비교하는 등의 로직이 추가되었는데, 이 부분이 비효율적인 거 같습니다.
- dto를 *CreateRequest, *FindRequest, *UpdateResponse 등으로 많이 만들게 되었는데, 이것에 대해서 줄이는 게 좋을지 궁금합니다. (이것과 약간 별개로, 객체를 생성할 때는 password가 dto에 필요한데, update를 하거나 find를 할 때는 password를 읽어오면 안되어서 dto를 분리하기도 했는데, 이것은 잘 작성한 것인지 궁금합니다.) 
