### PR TITLE
[김지은] sprint3

### DIFF
--- a/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -1,5 +1,7 @@
 package com.sprint.mission.discodeit;
 
+import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
+import com.sprint.mission.discodeit.dto.request.MessageCreateRequest;
 import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.request.UserCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
@@ -12,6 +14,8 @@ import com.sprint.mission.discodeit.service.UserService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.List;
 
 @SpringBootApplication
 public class DiscodeitApplication {
@@ -26,7 +30,7 @@ public class DiscodeitApplication {
 	}
 
 	static void messageCreateTest(MessageService messageService, Channel channel, User author) {
-		Message message = messageService.create("안녕하세요.", channel.getId(), author.getId());
+		Message message = messageService.create(new MessageCreateRequest("안녕하세요.", channel.getId(), author.getId()), null);
 		System.out.println("메시지 생성: " + message.getId());
 	}
 

--- a/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
+++ b/src/main/java/com/sprint/mission/discodeit/DiscodeitApplication.java
@@ -1,5 +1,6 @@
 package com.sprint.mission.discodeit;
 
+import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.request.UserCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.ChannelType;
@@ -20,7 +21,7 @@ public class DiscodeitApplication {
 	}
 
 	static Channel setupChannel(ChannelService channelService) {
-		Channel channel = channelService.create(ChannelType.PUBLIC, "공지", "공지 채널입니다.");
+		Channel channel = channelService.create(new PublicChannelCreateRequest("공지", "공지 채널입니다."));
 		return channel;
 	}
 

--- a/src/main/java/com/sprint/mission/discodeit/dto/data/ChannelDto.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/data/ChannelDto.java
@@ -1,0 +1,17 @@
+package com.sprint.mission.discodeit.dto.data;
+
+import com.sprint.mission.discodeit.entity.ChannelType;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record ChannelDto(
+        UUID id,
+        ChannelType type,
+        String name,
+        String description,
+        List<UUID> participantIds,
+        Instant lastMessageAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/BinaryContentCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/BinaryContentCreateRequest.java
@@ -3,7 +3,6 @@ package com.sprint.mission.discodeit.dto.request;
 public record BinaryContentCreateRequest (
     String fileName,
     String contentType,
-    Long size,
     byte[] binaryContent
 ){
 }

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/ChannelUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/ChannelUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto.request;
+
+import java.util.UUID;
+
+public record ChannelUpdateRequest(
+        String newName,
+        String newDescription
+) {
+
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/LoginRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/LoginRequest.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.dto.request;
+
+public record LoginRequest(
+        String username,
+        String password
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/MessageCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/MessageCreateRequest.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto.request;
+
+import java.util.UUID;
+
+public record MessageCreateRequest(
+        String content,
+        UUID channelId,
+        UUID authorId
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/MessageUpdatedRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/MessageUpdatedRequest.java
@@ -1,0 +1,6 @@
+package com.sprint.mission.discodeit.dto.request;
+
+public record MessageUpdatedRequest(
+        String newContent
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/PrivateChannelCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/PrivateChannelCreateRequest.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.dto.request;
+
+import com.sprint.mission.discodeit.entity.User;
+
+import java.util.List;
+import java.util.UUID;
+
+public record PrivateChannelCreateRequest(
+        List<UUID> participantIds
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/PublicChannelCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/PublicChannelCreateRequest.java
@@ -1,0 +1,7 @@
+package com.sprint.mission.discodeit.dto.request;
+
+public record PublicChannelCreateRequest(
+        String name,
+        String description
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/ReadStatusCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/ReadStatusCreateRequest.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.discodeit.dto.request;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReadStatusCreateRequest(
+        UUID userId,
+        UUID channelId,
+        Instant lastReadAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/ReadStatusUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/ReadStatusUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.sprint.mission.discodeit.dto.request;
+
+import java.time.Instant;
+
+public record ReadStatusUpdateRequest(
+        Instant newLastReadAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/UserStatusCreateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/UserStatusCreateRequest.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.discodeit.dto.request;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserStatusCreateRequest(
+        UUID userId,
+        Instant lastActiveAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/dto/request/UserStatusUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/discodeit/dto/request/UserStatusUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.sprint.mission.discodeit.dto.request;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserStatusUpdateRequest(
+        Instant newLastActiveAt
+) {
+}

--- a/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/BinaryContent.java
@@ -17,15 +17,13 @@ public class BinaryContent implements Serializable {
     //
     private final String fileName;
     private final String contentType;
-    private final Long size;
     private final byte[] binaryContent;
 
-    public BinaryContent(String fileName, String contentType, Long size, byte[] binaryContent){
+    public BinaryContent(String fileName, String contentType, byte[] binaryContent){
         this.id = UUID.randomUUID();
         this.createdAt = Instant.now();
         this.fileName = fileName;
         this.contentType = contentType;
-        this.size = size;
         this.binaryContent = binaryContent;
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/Message.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/Message.java
@@ -32,6 +32,16 @@ public class Message implements Serializable {
         this.authorId = authorId;
     }
 
+    public Message(String content, UUID channelId, UUID authorId, List<UUID> attachmentIds) {
+        this.id = UUID.randomUUID();
+        this.createdAt = Instant.now();
+        //
+        this.content = content;
+        this.channelId = channelId;
+        this.authorId = authorId;
+        this.attachmentIds = attachmentIds;
+    }
+
     public void update(String newContent) {
         boolean anyValueUpdated = false;
         if (newContent != null && !newContent.equals(this.content)) {

--- a/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/ReadStatus.java
@@ -18,16 +18,19 @@ public class ReadStatus implements Serializable {
     //
     private final UUID userId;
     private final UUID channelId;
+    private Instant lastReadAt;
 
-    public ReadStatus(UUID userId, UUID channelId) {
+    public ReadStatus(UUID userId, UUID channelId, Instant lastReadAt) {
         this.id = UUID.randomUUID();
         this.createdAt = Instant.now();
         //
         this.userId = userId;
         this.channelId = channelId;
+        this.lastReadAt = lastReadAt;
     }
 
     public void updateReadStatus(Instant readTime){
         this.updatedAt = readTime;
+        this.lastReadAt = readTime;
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
+++ b/src/main/java/com/sprint/mission/discodeit/entity/UserStatus.java
@@ -21,19 +21,20 @@ public class UserStatus implements Serializable {
     private final UUID userId;
     private Instant lastLogin;
 
-    public UserStatus(UUID userId){
+    public UserStatus(UUID userId, Instant lastLogin) {
         this.id = UUID.randomUUID();
         this.createdAt = Instant.now();
         //
         this.userId = userId;
+        this.lastLogin = lastLogin;
     }
 
-    public void updateLastLogin(){
-        this.updatedAt = Instant.now();
-        this.lastLogin = Instant.now();
+    public void updateLastLogin(Instant time) {
+        this.updatedAt = time;
+        this.lastLogin = time;
     }
 
-    public boolean isLogin(){
+    public boolean isLogin() {
         return lastLogin.isBefore(Instant.now().minus(Duration.ofMinutes(5)));
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/BinaryContentRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/BinaryContentRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public interface BinaryContentRepository {
     BinaryContent save(BinaryContent binaryContent);
     Optional<BinaryContent> findById(UUID id);
-    List<BinaryContent> findAll();
+    List<BinaryContent> findAllByInIds(List<UUID> ids);
     boolean existsById(UUID id);
     void deleteById(UUID id);
 

--- a/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public interface MessageRepository {
     Message save(Message message);
     Optional<Message> findById(UUID id);
-    List<Message> findAll();
+    List<Message> findAllByChannelId(UUID channelId);
     boolean existsById(UUID id);
     void deleteById(UUID id);
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/MessageRepository.java
@@ -12,4 +12,5 @@ public interface MessageRepository {
     List<Message> findAllByChannelId(UUID channelId);
     boolean existsById(UUID id);
     void deleteById(UUID id);
+    void deleteAllByChannelId(UUID channelId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
@@ -6,9 +6,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface ReadStatusRepositoty {
+public interface ReadStatusRepository {
     ReadStatus save(ReadStatus readStatus);
     Optional<ReadStatus> findById(UUID id);
+    List<ReadStatus> findByChannelId(UUID channelId);
     List<ReadStatus> findAll();
     boolean existsById(UUID id);
     void deleteById(UUID id);

--- a/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
@@ -10,6 +10,7 @@ public interface ReadStatusRepository {
     ReadStatus save(ReadStatus readStatus);
     Optional<ReadStatus> findById(UUID id);
     List<ReadStatus> findByChannelId(UUID channelId);
+    List<ReadStatus> findByUserId(UUID userId);
     List<ReadStatus> findAll();
     boolean existsById(UUID id);
     void deleteById(UUID id);

--- a/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/ReadStatusRepository.java
@@ -14,4 +14,5 @@ public interface ReadStatusRepository {
     List<ReadStatus> findAll();
     boolean existsById(UUID id);
     void deleteById(UUID id);
+    void deleteAllByChannelId(UUID channelId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/UserRepository.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public interface UserRepository {
     User save(User user);
     Optional<User> findById(UUID id);
+    Optional<User> findByUsername(String username);
     List<User> findAll();
     boolean existsById(UUID id);
     void deleteById(UUID id);

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileBinaryContentRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileBinaryContentRepository.java
@@ -64,7 +64,7 @@ public class FileBinaryContentRepository implements BinaryContentRepository {
     }
 
     @Override
-    public List<BinaryContent> findAll() {
+    public List<BinaryContent> findAllByInIds(List<UUID> ids) {
         try {
             return Files.list(DIRECTORY)
                     .filter(path -> path.toString().endsWith(EXTENSION))
@@ -78,6 +78,7 @@ public class FileBinaryContentRepository implements BinaryContentRepository {
                             throw new RuntimeException(e);
                         }
                     })
+                    .filter(binaryContent -> ids.contains(binaryContent.getId()))
                     .toList();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
@@ -64,7 +64,7 @@ public class FileMessageRepository implements MessageRepository {
     }
 
     @Override
-    public List<Message> findAll() {
+    public List<Message> findAllByChannelId(UUID channelId) {
         try {
             return Files.list(DIRECTORY)
                     .filter(path -> path.toString().endsWith(EXTENSION))
@@ -78,6 +78,7 @@ public class FileMessageRepository implements MessageRepository {
                             throw new RuntimeException(e);
                         }
                     })
+                    .filter(message -> message.getChannelId().equals(channelId))
                     .toList();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileMessageRepository.java
@@ -100,4 +100,10 @@ public class FileMessageRepository implements MessageRepository {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public void deleteAllByChannelId(UUID channelId) {
+        findAllByChannelId(channelId)
+                .forEach(message -> deleteById(message.getId()));
+    }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
@@ -115,4 +115,10 @@ public class FileReadStatusRepository implements ReadStatusRepository {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public void deleteAllByChannelId(UUID channelId) {
+       findByChannelId(channelId).
+               forEach(readStatus -> deleteById(readStatus.getId()));
+    }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
@@ -1,9 +1,7 @@
 package com.sprint.mission.discodeit.repository.file;
 
 import com.sprint.mission.discodeit.entity.ReadStatus;
-import com.sprint.mission.discodeit.entity.UserStatus;
 import com.sprint.mission.discodeit.repository.ReadStatusRepository;
-import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import org.springframework.stereotype.Repository;
 
 import java.io.*;
@@ -118,7 +116,7 @@ public class FileReadStatusRepository implements ReadStatusRepository {
 
     @Override
     public void deleteAllByChannelId(UUID channelId) {
-       findByChannelId(channelId).
-               forEach(readStatus -> deleteById(readStatus.getId()));
+        findByChannelId(channelId).
+                forEach(readStatus -> deleteById(readStatus.getId()));
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
@@ -73,6 +73,13 @@ public class FileReadStatusRepository implements ReadStatusRepository {
     }
 
     @Override
+    public List<ReadStatus> findByUserId(UUID userId) {
+        return findAll().stream()
+                .filter(readStatus -> readStatus.getUserId().equals(userId))
+                .toList();
+    }
+
+    @Override
     public List<ReadStatus> findAll() {
         try {
             return Files.list(DIRECTORY)

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileReadStatusRepository.java
@@ -2,6 +2,7 @@ package com.sprint.mission.discodeit.repository.file;
 
 import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.entity.UserStatus;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,12 +15,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public class FileUserStatusRepository implements UserStatusRepository {
+public class FileReadStatusRepository implements ReadStatusRepository {
     private final Path DIRECTORY;
     private final String EXTENSION = ".ser";
 
-    public FileUserStatusRepository() {
-        this.DIRECTORY = Paths.get(System.getProperty("user.dir"), "file-data-map", UserStatus.class.getSimpleName());
+    public FileReadStatusRepository() {
+        this.DIRECTORY = Paths.get(System.getProperty("user.dir"), "file-data-map", ReadStatus.class.getSimpleName());
         if (Files.notExists(DIRECTORY)) {
             try {
                 Files.createDirectories(DIRECTORY);
@@ -34,45 +35,45 @@ public class FileUserStatusRepository implements UserStatusRepository {
     }
 
     @Override
-    public UserStatus save(UserStatus userStatus) {
-        Path path = resolvePath(userStatus.getId());
+    public ReadStatus save(ReadStatus readStatus) {
+        Path path = resolvePath(readStatus.getId());
         try (
                 FileOutputStream fos = new FileOutputStream(path.toFile());
                 ObjectOutputStream oos = new ObjectOutputStream(fos)
         ) {
-            oos.writeObject(userStatus);
+            oos.writeObject(readStatus);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return userStatus;
+        return readStatus;
     }
 
     @Override
-    public Optional<UserStatus> findById(UUID id) {
-        UserStatus userStatusNullable = null;
+    public Optional<ReadStatus> findById(UUID id) {
+        ReadStatus readStatusNullable = null;
         Path path = resolvePath(id);
         if (Files.exists(path)) {
             try (
                     FileInputStream fis = new FileInputStream(path.toFile());
                     ObjectInputStream ois = new ObjectInputStream(fis)
             ) {
-                userStatusNullable = (UserStatus) ois.readObject();
+                readStatusNullable = (ReadStatus) ois.readObject();
             } catch (IOException | ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }
         }
-        return Optional.ofNullable(userStatusNullable);
+        return Optional.ofNullable(readStatusNullable);
     }
 
     @Override
-    public Optional<UserStatus> findByUserId(UUID userId) {
+    public List<ReadStatus> findByChannelId(UUID channelId) {
         return findAll().stream()
-                .filter(userStatus -> userStatus.getUserId().equals(userId))
-                .findFirst();
+                .filter(readStatus -> readStatus.getChannelId().equals(channelId))
+                .toList();
     }
 
     @Override
-    public List<UserStatus> findAll() {
+    public List<ReadStatus> findAll() {
         try {
             return Files.list(DIRECTORY)
                     .filter(path -> path.toString().endsWith(EXTENSION))
@@ -81,7 +82,7 @@ public class FileUserStatusRepository implements UserStatusRepository {
                                 FileInputStream fis = new FileInputStream(path.toFile());
                                 ObjectInputStream ois = new ObjectInputStream(fis)
                         ) {
-                            return (UserStatus) ois.readObject();
+                            return (ReadStatus) ois.readObject();
                         } catch (IOException | ClassNotFoundException e) {
                             throw new RuntimeException(e);
                         }
@@ -106,11 +107,5 @@ public class FileUserStatusRepository implements UserStatusRepository {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public void deleteByUserId(UUID userId) {
-        this.findByUserId(userId)
-                .ifPresent(userStatus -> this.deleteById(userStatus.getId()));
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserRepository.java
@@ -64,6 +64,13 @@ public class FileUserRepository implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByUsername(String username) {
+        return findAll().stream()
+                .filter(user -> user.getUsername().equals(username))
+                .findFirst();
+    }
+
+    @Override
     public List<User> findAll() {
         try {
             return Files.list(DIRECTORY)
@@ -102,13 +109,13 @@ public class FileUserRepository implements UserRepository {
 
     @Override
     public boolean existsByUsername(String username) {
-        return this.findAll().stream()
+        return findAll().stream()
                 .anyMatch(user -> user.getUsername().equals(username));
     }
 
     @Override
     public boolean existsByEmail(String email) {
-        return this.findAll().stream()
+        return findAll().stream()
                 .anyMatch(user -> user.getUsername().equals(email));
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserStatusRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/file/FileUserStatusRepository.java
@@ -1,6 +1,5 @@
 package com.sprint.mission.discodeit.repository.file;
 
-import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.entity.UserStatus;
 import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFMessageRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFMessageRepository.java
@@ -24,8 +24,8 @@ public class JCFMessageRepository implements MessageRepository {
     }
 
     @Override
-    public List<Message> findAll() {
-        return this.data.values().stream().toList();
+    public List<Message> findAllByChannelId(UUID channelId) {
+        return List.of();
     }
 
     @Override
@@ -36,5 +36,10 @@ public class JCFMessageRepository implements MessageRepository {
     @Override
     public void deleteById(UUID id) {
         this.data.remove(id);
+    }
+
+    @Override
+    public void deleteAllByChannelId(UUID channelId) {
+
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFUserRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/jcf/JCFUserRepository.java
@@ -24,6 +24,11 @@ public class JCFUserRepository implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByUsername(String username) {
+        return Optional.empty();
+    }
+
+    @Override
     public List<User> findAll() {
         return this.data.values().stream().toList();
     }

--- a/src/main/java/com/sprint/mission/discodeit/service/AuthService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.request.LoginRequest;
+import com.sprint.mission.discodeit.entity.User;
+
+public interface AuthService {
+    User login(LoginRequest loginRequest);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/BinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/BinaryContentService.java
@@ -1,0 +1,14 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
+import com.sprint.mission.discodeit.entity.BinaryContent;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BinaryContentService {
+    BinaryContent create(BinaryContentCreateRequest binaryContentCreateRequest);
+    BinaryContent find(UUID id);
+    List<BinaryContent> findAllByIdIn(List<UUID> binaryContentIds);
+    void delete(UUID id);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -1,5 +1,6 @@
 package com.sprint.mission.discodeit.service;
 
+import com.sprint.mission.discodeit.dto.data.ChannelDto;
 import com.sprint.mission.discodeit.dto.request.PrivateChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
@@ -11,7 +12,7 @@ import java.util.UUID;
 public interface ChannelService {
     Channel create(PublicChannelCreateRequest publicChannelCreateRequest);
     Channel create(PrivateChannelCreateRequest privateChannelCreateRequest);
-    Channel find(UUID channelId);
+    ChannelDto find(UUID channelId);
     List<Channel> findAll();
     Channel update(UUID channelId, String newName, String newDescription);
     void delete(UUID channelId);

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -5,7 +5,6 @@ import com.sprint.mission.discodeit.dto.request.ChannelUpdateRequest;
 import com.sprint.mission.discodeit.dto.request.PrivateChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
-import com.sprint.mission.discodeit.entity.ChannelType;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -1,5 +1,7 @@
 package com.sprint.mission.discodeit.service;
 
+import com.sprint.mission.discodeit.dto.request.PrivateChannelCreateRequest;
+import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.ChannelType;
 
@@ -7,7 +9,8 @@ import java.util.List;
 import java.util.UUID;
 
 public interface ChannelService {
-    Channel create(ChannelType type, String name, String description);
+    Channel create(PublicChannelCreateRequest publicChannelCreateRequest);
+    Channel create(PrivateChannelCreateRequest privateChannelCreateRequest);
     Channel find(UUID channelId);
     List<Channel> findAll();
     Channel update(UUID channelId, String newName, String newDescription);

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.discodeit.service;
 
 import com.sprint.mission.discodeit.dto.data.ChannelDto;
+import com.sprint.mission.discodeit.dto.request.ChannelUpdateRequest;
 import com.sprint.mission.discodeit.dto.request.PrivateChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
@@ -15,6 +16,6 @@ public interface ChannelService {
     ChannelDto find(UUID channelId);
     List<ChannelDto> findAll();
     List<ChannelDto> findAllByUserId(UUID userId);
-    Channel update(UUID channelId, String newName, String newDescription);
+    Channel update(UUID channelId, ChannelUpdateRequest channelUpdateRequest);
     void delete(UUID channelId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ChannelService.java
@@ -13,7 +13,8 @@ public interface ChannelService {
     Channel create(PublicChannelCreateRequest publicChannelCreateRequest);
     Channel create(PrivateChannelCreateRequest privateChannelCreateRequest);
     ChannelDto find(UUID channelId);
-    List<Channel> findAll();
+    List<ChannelDto> findAll();
+    List<ChannelDto> findAllByUserId(UUID userId);
     Channel update(UUID channelId, String newName, String newDescription);
     void delete(UUID channelId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
@@ -1,14 +1,16 @@
 package com.sprint.mission.discodeit.service;
 
+import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
+import com.sprint.mission.discodeit.dto.request.MessageCreateRequest;
 import com.sprint.mission.discodeit.entity.Message;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface MessageService {
-    Message create(String content, UUID channelId, UUID authorId);
+    Message create(MessageCreateRequest messageCreateRequest, List<BinaryContentCreateRequest> binaryContentCreateRequests);
     Message find(UUID messageId);
-    List<Message> findAll();
+    List<Message>findAllByChannelId(UUID channelId);
     Message update(UUID messageId, String newContent);
     void delete(UUID messageId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/MessageService.java
@@ -2,6 +2,7 @@ package com.sprint.mission.discodeit.service;
 
 import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.dto.request.MessageCreateRequest;
+import com.sprint.mission.discodeit.dto.request.MessageUpdatedRequest;
 import com.sprint.mission.discodeit.entity.Message;
 
 import java.util.List;
@@ -11,6 +12,6 @@ public interface MessageService {
     Message create(MessageCreateRequest messageCreateRequest, List<BinaryContentCreateRequest> binaryContentCreateRequests);
     Message find(UUID messageId);
     List<Message>findAllByChannelId(UUID channelId);
-    Message update(UUID messageId, String newContent);
+    Message update(UUID messageId, MessageUpdatedRequest messageUpdatedRequest);
     void delete(UUID messageId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/ReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ReadStatusService.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.request.ReadStatusCreateRequest;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ReadStatusService {
+    ReadStatus create(ReadStatusCreateRequest readStatusCreateRequest);
+    ReadStatus find(UUID readStatusId);
+    List<ReadStatus>findAllByUserId(UUID userId);
+    ReadStatus update();
+    void delete(UUID readStatusId);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/ReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/ReadStatusService.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.discodeit.service;
 
 import com.sprint.mission.discodeit.dto.request.ReadStatusCreateRequest;
+import com.sprint.mission.discodeit.dto.request.ReadStatusUpdateRequest;
 import com.sprint.mission.discodeit.entity.ReadStatus;
 
 import java.util.List;
@@ -10,6 +11,6 @@ public interface ReadStatusService {
     ReadStatus create(ReadStatusCreateRequest readStatusCreateRequest);
     ReadStatus find(UUID readStatusId);
     List<ReadStatus>findAllByUserId(UUID userId);
-    ReadStatus update();
+    ReadStatus update(UUID readStatusId, ReadStatusUpdateRequest readStatusUpdateRequest);
     void delete(UUID readStatusId);
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/UserStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserStatusService.java
@@ -1,10 +1,7 @@
 package com.sprint.mission.discodeit.service;
 
-import com.sprint.mission.discodeit.dto.request.ReadStatusCreateRequest;
-import com.sprint.mission.discodeit.dto.request.ReadStatusUpdateRequest;
 import com.sprint.mission.discodeit.dto.request.UserStatusCreateRequest;
 import com.sprint.mission.discodeit.dto.request.UserStatusUpdateRequest;
-import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.entity.UserStatus;
 
 import java.util.List;

--- a/src/main/java/com/sprint/mission/discodeit/service/UserStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/UserStatusService.java
@@ -1,0 +1,20 @@
+package com.sprint.mission.discodeit.service;
+
+import com.sprint.mission.discodeit.dto.request.ReadStatusCreateRequest;
+import com.sprint.mission.discodeit.dto.request.ReadStatusUpdateRequest;
+import com.sprint.mission.discodeit.dto.request.UserStatusCreateRequest;
+import com.sprint.mission.discodeit.dto.request.UserStatusUpdateRequest;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.entity.UserStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserStatusService {
+    UserStatus create(UserStatusCreateRequest userStatusCreateRequest);
+    UserStatus find(UUID userStatusId);
+    List<UserStatus> findAll();
+    UserStatus update(UUID userStatusId, UserStatusUpdateRequest userStatusUpdateRequest);
+    UserStatus updateByUserId(UUID userId, UserStatusUpdateRequest userStatusUpdateRequest);
+    void delete(UUID userStatusId);
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicAuthService.java
@@ -1,0 +1,26 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.request.LoginRequest;
+import com.sprint.mission.discodeit.entity.User;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.AuthService;
+
+import java.util.NoSuchElementException;
+
+public class BasicAuthService implements AuthService {
+    private UserRepository userRepository;
+
+    @Override
+    public User login(LoginRequest loginRequest) {
+        String username = loginRequest.username();
+        String password = loginRequest.password();
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException(username + "를 찾을 수 없습니다"));
+
+        if (!user.getPassword().equals(password)) {
+            throw new NoSuchElementException("비밀번호가 틀렸습니다");
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicBinaryContentService.java
@@ -1,0 +1,47 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
+import com.sprint.mission.discodeit.entity.BinaryContent;
+import com.sprint.mission.discodeit.repository.BinaryContentRepository;
+import com.sprint.mission.discodeit.service.BinaryContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BasicBinaryContentService implements BinaryContentService {
+    private final BinaryContentRepository binaryContentRepository;
+
+    @Override
+    public BinaryContent create(BinaryContentCreateRequest binaryContentCreateRequest) {
+        String fileName = binaryContentCreateRequest.fileName();
+        String contentType = binaryContentCreateRequest.contentType();
+        byte[] content = binaryContentCreateRequest.binaryContent();
+
+        BinaryContent binaryContent = new BinaryContent(fileName, contentType, content);
+        return binaryContentRepository.save(binaryContent);
+    }
+
+    @Override
+    public BinaryContent find(UUID id) {
+        return binaryContentRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("BinaryContent with id " + id + " not found"));
+    }
+
+    @Override
+    public List<BinaryContent> findAllByIdIn(List<UUID> binaryContentIds) {
+        return binaryContentRepository.findAllByInIds(binaryContentIds);
+    }
+
+    @Override
+    public void delete(UUID id) {
+        if (!binaryContentRepository.existsById(id)) {
+            throw new NoSuchElementException("BinaryContent with id " + id + " not found");
+        }
+        binaryContentRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -40,7 +40,7 @@ public class BasicChannelService implements ChannelService {
         Channel createChannel = channelRepository.save(channel);
 
         privateChannelCreateRequest.participantIds().stream()
-                .map(userId -> new ReadStatus(userId, channel.getId()))
+                .map(userId -> new ReadStatus(userId, channel.getId(), Instant.MIN))
                 .forEach(readStatusRepository::save);
         return createChannel;
     }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -92,7 +92,7 @@ public class BasicChannelService implements ChannelService {
     @Override
     public void delete(UUID channelId) {
         Channel channel = channelRepository.findById(channelId)
-                .orElseThrow( ()->new NoSuchElementException("Channel with id " + channelId + " not found"));
+                .orElseThrow(() -> new NoSuchElementException("Channel with id " + channelId + " not found"));
 
         messageRepository.deleteAllByChannelId(channel.getId());
         readStatusRepository.deleteAllByChannelId(channel.getId());

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -52,8 +52,24 @@ public class BasicChannelService implements ChannelService {
     }
 
     @Override
-    public List<Channel> findAll() {
-        return channelRepository.findAll();
+    public List<ChannelDto> findAll() {
+        return channelRepository.findAll()
+                .stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    @Override
+    public List<ChannelDto> findAllByUserId(UUID userId) {
+        List<UUID> mySubscribedChannelIds = readStatusRepository.findByUserId(userId).stream()
+                .map(ReadStatus::getChannelId)
+                .toList();
+
+        return channelRepository.findAll().stream()
+                .filter(channel ->
+                        channel.getType() == ChannelType.PRIVATE || mySubscribedChannelIds.contains(channel.getId()))
+                .map(this::toDto)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -1,8 +1,13 @@
 package com.sprint.mission.discodeit.service.basic;
 
+import com.sprint.mission.discodeit.dto.request.PrivateChannelCreateRequest;
+import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.MessageRepository;
+import com.sprint.mission.discodeit.repository.ReadStatusRepositoty;
 import com.sprint.mission.discodeit.service.ChannelService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,17 +20,33 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class BasicChannelService implements ChannelService {
     private final ChannelRepository channelRepository;
+    private final ReadStatusRepositoty readStatusRepositoty;
+    private final MessageRepository messageRepository;
 
     @Override
-    public Channel create(ChannelType type, String name, String description) {
-        Channel channel = new Channel(type, name, description);
+    public Channel create(PublicChannelCreateRequest publicChannelCreateRequest) {
+        String name = publicChannelCreateRequest.name();
+        String description = publicChannelCreateRequest.description();
+
+        Channel channel = new Channel(ChannelType.PUBLIC, name, description);
         return channelRepository.save(channel);
+    }
+
+    @Override
+    public Channel create(PrivateChannelCreateRequest privateChannelCreateRequest) {
+        Channel channel = new Channel(ChannelType.PRIVATE, null, null);
+        Channel createChannel = channelRepository.save(channel);
+
+        privateChannelCreateRequest.participantIds().stream()
+                .map(userId -> new ReadStatus(userId, channel.getId()))
+                .forEach(readStatusRepositoty::save);
+        return createChannel;
     }
 
     @Override
     public Channel find(UUID channelId) {
         return channelRepository.findById(channelId)
-                        .orElseThrow(() -> new NoSuchElementException("Channel with id " + channelId + " not found"));
+                .orElseThrow(() -> new NoSuchElementException("Channel with id " + channelId + " not found"));
     }
 
     @Override

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -91,9 +91,12 @@ public class BasicChannelService implements ChannelService {
 
     @Override
     public void delete(UUID channelId) {
-        if (!channelRepository.existsById(channelId)) {
-            throw new NoSuchElementException("Channel with id " + channelId + " not found");
-        }
+        Channel channel = channelRepository.findById(channelId)
+                .orElseThrow( ()->new NoSuchElementException("Channel with id " + channelId + " not found"));
+
+        messageRepository.deleteAllByChannelId(channel.getId());
+        readStatusRepository.deleteAllByChannelId(channel.getId());
+
         channelRepository.deleteById(channelId);
     }
 

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.dto.data.ChannelDto;
+import com.sprint.mission.discodeit.dto.request.ChannelUpdateRequest;
 import com.sprint.mission.discodeit.dto.request.PrivateChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
@@ -73,9 +74,17 @@ public class BasicChannelService implements ChannelService {
     }
 
     @Override
-    public Channel update(UUID channelId, String newName, String newDescription) {
+    public Channel update(UUID channelId, ChannelUpdateRequest channelUpdateRequest) {
         Channel channel = channelRepository.findById(channelId)
                 .orElseThrow(() -> new NoSuchElementException("Channel with id " + channelId + " not found"));
+
+        if (channel.getType() == ChannelType.PRIVATE) {
+            throw new IllegalArgumentException("private channel cannot be updated");
+        }
+
+        String newName = channelUpdateRequest.newName();
+        String newDescription = channelUpdateRequest.newDescription();
+
         channel.update(newName, newDescription);
         return channelRepository.save(channel);
     }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicChannelService.java
@@ -1,26 +1,27 @@
 package com.sprint.mission.discodeit.service.basic;
 
+import com.sprint.mission.discodeit.dto.data.ChannelDto;
 import com.sprint.mission.discodeit.dto.request.PrivateChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.request.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.ChannelType;
+import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.MessageRepository;
-import com.sprint.mission.discodeit.repository.ReadStatusRepositoty;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.service.ChannelService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.UUID;
+import java.time.Instant;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class BasicChannelService implements ChannelService {
     private final ChannelRepository channelRepository;
-    private final ReadStatusRepositoty readStatusRepositoty;
+    private final ReadStatusRepository readStatusRepository;
     private final MessageRepository messageRepository;
 
     @Override
@@ -39,13 +40,14 @@ public class BasicChannelService implements ChannelService {
 
         privateChannelCreateRequest.participantIds().stream()
                 .map(userId -> new ReadStatus(userId, channel.getId()))
-                .forEach(readStatusRepositoty::save);
+                .forEach(readStatusRepository::save);
         return createChannel;
     }
 
     @Override
-    public Channel find(UUID channelId) {
+    public ChannelDto find(UUID channelId) {
         return channelRepository.findById(channelId)
+                .map(this::toDto)
                 .orElseThrow(() -> new NoSuchElementException("Channel with id " + channelId + " not found"));
     }
 
@@ -68,5 +70,32 @@ public class BasicChannelService implements ChannelService {
             throw new NoSuchElementException("Channel with id " + channelId + " not found");
         }
         channelRepository.deleteById(channelId);
+    }
+
+    private ChannelDto toDto(Channel channel) {
+        Instant lastMessageAt = messageRepository.findAllByChannelId(channel.getId())
+                .stream()
+                .sorted(Comparator.comparing(Message::getCreatedAt).reversed())
+                .map(Message::getCreatedAt)
+                .limit(1)
+                .findFirst()
+                .orElse(Instant.MIN);
+
+        List<UUID> participantIds = new ArrayList<>();
+        if (channel.getType() == ChannelType.PRIVATE) {
+            readStatusRepository.findByChannelId(channel.getId())
+                    .stream()
+                    .map(ReadStatus::getUserId)
+                    .forEach(participantIds::add);
+        }
+
+        return new ChannelDto(
+                channel.getId(),
+                channel.getType(),
+                channel.getName(),
+                channel.getDescription(),
+                participantIds,
+                lastMessageAt
+        );
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -1,6 +1,10 @@
 package com.sprint.mission.discodeit.service.basic;
 
+import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
+import com.sprint.mission.discodeit.dto.request.MessageCreateRequest;
+import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.entity.Message;
+import com.sprint.mission.discodeit.repository.BinaryContentRepository;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.MessageRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
@@ -18,9 +22,13 @@ public class BasicMessageService implements MessageService {
     private final MessageRepository messageRepository;
     private final ChannelRepository channelRepository;
     private final UserRepository userRepository;
+    private final BinaryContentRepository binaryContentRepository;
 
     @Override
-    public Message create(String content, UUID channelId, UUID authorId) {
+    public Message create(MessageCreateRequest messageCreateRequest, List<BinaryContentCreateRequest> binaryContentCreateRequests) {
+        UUID channelId = messageCreateRequest.channelId();
+        UUID authorId = messageCreateRequest.authorId();
+
         if (!channelRepository.existsById(channelId)) {
             throw new NoSuchElementException("Channel not found with id " + channelId);
         }
@@ -28,7 +36,20 @@ public class BasicMessageService implements MessageService {
             throw new NoSuchElementException("Author not found with id " + authorId);
         }
 
-        Message message = new Message(content, channelId, authorId);
+        List<UUID> attachmentIds = binaryContentCreateRequests.stream()
+                .map(attachmentRequest -> {
+                    String fileName = attachmentRequest.fileName();
+                    String contentType = attachmentRequest.contentType();
+                    byte[] bytes = attachmentRequest.binaryContent();
+
+                    BinaryContent binaryContent = new BinaryContent(fileName, contentType, bytes);
+                    BinaryContent createdBinaryContent = binaryContentRepository.save(binaryContent);
+                    return createdBinaryContent.getId();
+                })
+                .toList();
+
+        String content = messageCreateRequest.content();
+        Message message = new Message(content, channelId, authorId, attachmentIds);
         return messageRepository.save(message);
     }
 
@@ -39,8 +60,8 @@ public class BasicMessageService implements MessageService {
     }
 
     @Override
-    public List<Message> findAll() {
-        return messageRepository.findAll();
+    public List<Message> findAllByChannelId(UUID channelId) {
+        return messageRepository.findAllByChannelId(channelId);
     }
 
     @Override

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -77,10 +77,10 @@ public class BasicMessageService implements MessageService {
     @Override
     public void delete(UUID messageId) {
         Message message = messageRepository.findById(messageId).
-           orElseThrow(()-> new NoSuchElementException("Message with id " + messageId + " not found"));
+                orElseThrow(() -> new NoSuchElementException("Message with id " + messageId + " not found"));
 
         message.getAttachmentIds()
-                        .forEach(binaryContentRepository::deleteById);
+                .forEach(binaryContentRepository::deleteById);
         messageRepository.deleteById(messageId);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -76,9 +76,11 @@ public class BasicMessageService implements MessageService {
 
     @Override
     public void delete(UUID messageId) {
-        if (!messageRepository.existsById(messageId)) {
-            throw new NoSuchElementException("Message with id " + messageId + " not found");
-        }
+        Message message = messageRepository.findById(messageId).
+           orElseThrow(()-> new NoSuchElementException("Message with id " + messageId + " not found"));
+
+        message.getAttachmentIds()
+                        .forEach(binaryContentRepository::deleteById);
         messageRepository.deleteById(messageId);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicMessageService.java
@@ -2,6 +2,7 @@ package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.dto.request.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.dto.request.MessageCreateRequest;
+import com.sprint.mission.discodeit.dto.request.MessageUpdatedRequest;
 import com.sprint.mission.discodeit.entity.BinaryContent;
 import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.repository.BinaryContentRepository;
@@ -65,7 +66,8 @@ public class BasicMessageService implements MessageService {
     }
 
     @Override
-    public Message update(UUID messageId, String newContent) {
+    public Message update(UUID messageId, MessageUpdatedRequest messageUpdatedRequest) {
+        String newContent = messageUpdatedRequest.newContent();
         Message message = messageRepository.findById(messageId)
                 .orElseThrow(() -> new NoSuchElementException("Message with id " + messageId + " not found"));
         message.update(newContent);

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -1,0 +1,64 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.request.ReadStatusCreateRequest;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.service.ReadStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BasicReadStatusService implements ReadStatusService {
+    private final ReadStatusRepository readStatusRepository;
+    private final UserRepository userRepository;
+    private final ChannelRepository channelRepository;
+
+    @Override
+    public ReadStatus create(ReadStatusCreateRequest readStatusCreateRequest) {
+        UUID userId = readStatusCreateRequest.userId();
+        UUID channelId = readStatusCreateRequest.channelId();
+
+        if (!channelRepository.existsById(channelId)) {
+            throw new NoSuchElementException("Channel not found with id " + channelId);
+        }
+        if (!userRepository.existsById(userId)) {
+            throw new NoSuchElementException("User not found with id " + userId);
+        }
+        if (readStatusRepository.findByUserId(userId).stream()
+                .anyMatch(readStatus -> readStatus.getChannelId().equals(channelId))) {
+            throw new IllegalArgumentException("userId and channelId already exists");
+        }
+
+        Instant lastReadAt = Instant.now();
+        ReadStatus readStatus = new ReadStatus(userId, channelId, lastReadAt);
+        return readStatusRepository.save(readStatus);
+    }
+
+    @Override
+    public ReadStatus find(UUID readStatusId) {
+        return null;
+    }
+
+    @Override
+    public List<ReadStatus> findAllByUserId(UUID userId) {
+        return List.of();
+    }
+
+    @Override
+    public ReadStatus update() {
+        return null;
+    }
+
+    @Override
+    public void delete(UUID readStatusId) {
+
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -67,8 +67,8 @@ public class BasicReadStatusService implements ReadStatusService {
 
     @Override
     public void delete(UUID readStatusId) {
-        if(!readStatusRepository.existsById(readStatusId)){
-                throw new NoSuchElementException("ReadStatus not found with id " + readStatusId);
+        if (!readStatusRepository.existsById(readStatusId)) {
+            throw new NoSuchElementException("ReadStatus not found with id " + readStatusId);
         }
         readStatusRepository.deleteById(readStatusId);
     }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.discodeit.service.basic;
 
 import com.sprint.mission.discodeit.dto.request.ReadStatusCreateRequest;
+import com.sprint.mission.discodeit.dto.request.ReadStatusUpdateRequest;
 import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.repository.ChannelRepository;
 import com.sprint.mission.discodeit.repository.ReadStatusRepository;
@@ -44,17 +45,24 @@ public class BasicReadStatusService implements ReadStatusService {
 
     @Override
     public ReadStatus find(UUID readStatusId) {
-        return null;
+        return readStatusRepository.findById(readStatusId)
+                .orElseThrow(() -> new NoSuchElementException("ReadStatus not found with id " + readStatusId));
     }
 
     @Override
     public List<ReadStatus> findAllByUserId(UUID userId) {
-        return List.of();
+        return readStatusRepository.findByUserId(userId);
     }
 
     @Override
-    public ReadStatus update() {
-        return null;
+    public ReadStatus update(UUID readStatusId, ReadStatusUpdateRequest readStatusUpdateRequest) {
+        Instant newLastReadAt = readStatusUpdateRequest.newLastReadAt();
+
+        ReadStatus readStatus = readStatusRepository.findById(readStatusId)
+                .orElseThrow(() -> new NoSuchElementException("ReadStatus not found with id " + readStatusId));
+
+        readStatus.updateReadStatus(newLastReadAt);
+        return readStatusRepository.save(readStatus);
     }
 
     @Override

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicReadStatusService.java
@@ -67,6 +67,9 @@ public class BasicReadStatusService implements ReadStatusService {
 
     @Override
     public void delete(UUID readStatusId) {
-
+        if(!readStatusRepository.existsById(readStatusId)){
+                throw new NoSuchElementException("ReadStatus not found with id " + readStatusId);
+        }
+        readStatusRepository.deleteById(readStatusId);
     }
 }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -47,7 +48,7 @@ public class BasicUserService implements UserService {
             binaryContentRepository.save(profile);
         }
 
-        UserStatus userStatus = new UserStatus(user.getId());
+        UserStatus userStatus = new UserStatus(user.getId(), Instant.MIN);
 
         userRepository.save(user);
         userStatusRepository.save(userStatus);

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserService.java
@@ -42,8 +42,7 @@ public class BasicUserService implements UserService {
         User user = new User(userCreateRequest.username(), userCreateRequest.email(), userCreateRequest.password());
 
         if (binaryContentCreateRequest != null) {
-            BinaryContent profile = new BinaryContent(binaryContentCreateRequest.fileName(), binaryContentCreateRequest.contentType(),
-                    binaryContentCreateRequest.size(), binaryContentCreateRequest.binaryContent());
+            BinaryContent profile = new BinaryContent(binaryContentCreateRequest.fileName(), binaryContentCreateRequest.contentType(), binaryContentCreateRequest.binaryContent());
             user.updateProfile(profile.getId());
             binaryContentRepository.save(profile);
         }
@@ -75,8 +74,8 @@ public class BasicUserService implements UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchElementException("User with id " + userId + " not found"));
         if (binaryContentCreateRequest != null) {
-            BinaryContent profile = new BinaryContent(binaryContentCreateRequest.fileName(), binaryContentCreateRequest.contentType(),
-                    binaryContentCreateRequest.size(), binaryContentCreateRequest.binaryContent());
+            BinaryContent profile = new BinaryContent(binaryContentCreateRequest.fileName(), binaryContentCreateRequest.contentType()
+                    , binaryContentCreateRequest.binaryContent());
             user.updateProfile(profile.getId());
             binaryContentRepository.save(profile);
         }

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserStatusService.java
@@ -1,0 +1,82 @@
+package com.sprint.mission.discodeit.service.basic;
+
+import com.sprint.mission.discodeit.dto.request.ReadStatusUpdateRequest;
+import com.sprint.mission.discodeit.dto.request.UserStatusCreateRequest;
+import com.sprint.mission.discodeit.dto.request.UserStatusUpdateRequest;
+import com.sprint.mission.discodeit.entity.ReadStatus;
+import com.sprint.mission.discodeit.entity.UserStatus;
+import com.sprint.mission.discodeit.repository.ChannelRepository;
+import com.sprint.mission.discodeit.repository.ReadStatusRepository;
+import com.sprint.mission.discodeit.repository.UserRepository;
+import com.sprint.mission.discodeit.repository.UserStatusRepository;
+import com.sprint.mission.discodeit.service.UserStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BasicUserStatusService implements UserStatusService {
+    private final UserStatusRepository userStatusRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public UserStatus create(UserStatusCreateRequest userStatusCreateRequest) {
+        UUID userId = userStatusCreateRequest.userId();
+
+        if (!userRepository.existsById(userId)) {
+            throw new NoSuchElementException("User not found with id " + userId);
+        }
+        userStatusRepository.findByUserId(userId)
+                .orElseThrow(()->new IllegalArgumentException("userStatus has been already exists"));
+
+        Instant lastActiveAt = Instant.now();
+        UserStatus readStatus = new UserStatus(userId, lastActiveAt);
+        return userStatusRepository.save(readStatus);
+    }
+
+    @Override
+    public UserStatus find(UUID userStatusId) {
+        return userStatusRepository.findById(userStatusId)
+                .orElseThrow(() -> new NoSuchElementException("ReadStatus not found with id " + userStatusId));
+    }
+
+    @Override
+    public List<UserStatus> findAll() {
+        return userStatusRepository.findAll();
+    }
+
+    @Override
+    public UserStatus update(UUID userStatusId, UserStatusUpdateRequest userStatusUpdateRequest) {
+        Instant newLastActiveAt = userStatusUpdateRequest.newLastActiveAt();
+
+        UserStatus userStatus = userStatusRepository.findById(userStatusId)
+                .orElseThrow(() -> new NoSuchElementException("UserStatus not found with id " + userStatusId));
+
+        userStatus.updateLastLogin(newLastActiveAt);
+        return userStatusRepository.save(userStatus);
+    }
+
+    @Override
+    public UserStatus updateByUserId(UUID userId, UserStatusUpdateRequest userStatusUpdateRequest) {
+        Instant newLastActiveAt = userStatusUpdateRequest.newLastActiveAt();
+
+        UserStatus userStatus = userStatusRepository.findByUserId(userId)
+                .orElseThrow(() -> new NoSuchElementException("UserStatus not found with userId " + userId));
+
+        userStatus.updateLastLogin(newLastActiveAt);
+        return userStatusRepository.save(userStatus);
+    }
+
+    @Override
+    public void delete(UUID userStatusId) {
+        if (!userStatusRepository.existsById(userStatusId)) {
+            throw new NoSuchElementException("USerStatus not found with id " + userStatusId);
+        }
+        userStatusRepository.deleteById(userStatusId);
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserStatusService.java
+++ b/src/main/java/com/sprint/mission/discodeit/service/basic/BasicUserStatusService.java
@@ -1,12 +1,8 @@
 package com.sprint.mission.discodeit.service.basic;
 
-import com.sprint.mission.discodeit.dto.request.ReadStatusUpdateRequest;
 import com.sprint.mission.discodeit.dto.request.UserStatusCreateRequest;
 import com.sprint.mission.discodeit.dto.request.UserStatusUpdateRequest;
-import com.sprint.mission.discodeit.entity.ReadStatus;
 import com.sprint.mission.discodeit.entity.UserStatus;
-import com.sprint.mission.discodeit.repository.ChannelRepository;
-import com.sprint.mission.discodeit.repository.ReadStatusRepository;
 import com.sprint.mission.discodeit.repository.UserRepository;
 import com.sprint.mission.discodeit.repository.UserStatusRepository;
 import com.sprint.mission.discodeit.service.UserStatusService;
@@ -32,7 +28,7 @@ public class BasicUserStatusService implements UserStatusService {
             throw new NoSuchElementException("User not found with id " + userId);
         }
         userStatusRepository.findByUserId(userId)
-                .orElseThrow(()->new IllegalArgumentException("userStatus has been already exists"));
+                .orElseThrow(() -> new IllegalArgumentException("userStatus has been already exists"));
 
         Instant lastActiveAt = Instant.now();
         UserStatus readStatus = new UserStatus(userId, lastActiveAt);


### PR DESCRIPTION
## Spring 프로젝트 초기화
- [x] Spring Initializr로 Gradle-Groovy, Java 17, Spring Boot 3.4.0 프로젝트 생성
- [x] GroupId `com.sprint.mission`, ArtifactId & Name `discodeit`, packaging `Jar`
- [x] Lombok, Spring Web dependency 추가
- [x] zip 압축 해제 후 기존 프로젝트에 반영
- [x] `application.properties` → yaml 형식으로 변경
- [x] `DiscodeitApplication` 실행 및 로그 확인

## Bean 선언 및 테스트
- [x] File*Repository 구현체 Bean 등록
- [x] Basic*Service 구현체 Bean 등록
- [x] JavaApplication 코드 → DiscodeitApplication로 복사
- [x] Spring Context로 Service Bean 조회 방식 적용
- [x] 셋업·테스트 코드 복사 및 실행

## Spring 핵심 개념 정리 (PR 설명에 첨부)
- [ ] IoC Container / Dependency Injection / Bean 비교 및 정리

## Lombok 적용
- [x] 도메인 모델 getter → `@Getter` 적용
- [x] Basic*Service 생성자 → `@RequiredArgsConstructor` 적용

---

## 비즈니스 로직 고도화

### 시간 타입 변경
- [x] 시간 필드 타입을 `Instant`로 통일

### 새로운 도메인 추가
- [x] ReadStatus 도메인 모델 추가 (마지막 읽은 시간 포함)
- [x] UserStatus 도메인 모델 추가 (마지막 접속 시간, 5분 이내 접속 여부 메서드)
- [x] BinaryContent 도메인 모델 추가 (수정 불가, updatedAt 없음, 관계 필드 추가)
- [x] 각 도메인별 Repository 인터페이스 선언

---

## DTO 활용 및 서비스 고도화

### UserService
- [x] create: DTO 적용, username/email 중복 검사, 선택적 프로필 이미지 등록, UserStatus 생성
- [x] find / findAll: DTO로 온라인 상태 포함, 비밀번호 제외
- [x] update: DTO 적용, 선택적 프로필 이미지 변경
- [x] delete: 프로필 BinaryContent, UserStatus 같이 삭제

### AuthService
- [x] login: DTO 적용, username/password 일치 여부 검증, 예외 처리

### ChannelService
- [x] create: PRIVATE / PUBLIC 분리, DTO 적용, PRIVATE 시 ReadStatus 생성
- [x] find: DTO로 최근 메시지 시간, PRIVATE 시 참여 유저 ID 포함
- [x] findAllByUserId: PUBLIC 전체, PRIVATE 참여 채널만 조회
- [x] update: DTO 적용, PRIVATE 수정 불가
- [x] delete: Message, ReadStatus 같이 삭제

### MessageService
- [x] create: DTO 적용, 여러 첨부파일 등록 지원
- [x] findAllByChannelId: 채널별 메시지 목록 조회
- [x] update: DTO 적용
- [x] delete: 첨부 BinaryContent 같이 삭제

### ReadStatusService
- [x] create: DTO 적용, Channel/User 존재 여부, 중복 검사
- [x] find: id 조회
- [x] findAllByUserId: userId 조건 조회
- [x] update: DTO 적용
- [x] delete: id 삭제

### UserStatusService
- [x] create: DTO 적용, User 존재 여부, 중복 검사
- [x] find: id 조회
- [x] findAll: 전체 조회
- [x] update: DTO 적용
- [x] updateByUserId: userId로 업데이트
- [x] delete: id 삭제

### BinaryContentService
- [x] create: DTO 적용
- [x] find: id 조회
- [x] findAllByIdIn: id 목록 조회
- [x] delete: id 삭제

---

## Repository 구현체
- [ ] 각 도메인 Repository의 JCF, File 구현체 작성
